### PR TITLE
fix: Null Errors, using macros in url with pagination

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -682,8 +682,8 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
       }
     }
 
-    // Validate HTTP Error Handling Map
-    if (!containsMacro(PROPERTY_HTTP_ERROR_HANDLING)) {
+    // Validate HTTP Error Handling Map, fix: defer validation at runtime, when url contains a macro
+    if (!containsMacro(PROPERTY_URL) && !containsMacro(PROPERTY_HTTP_ERROR_HANDLING)) {
       List<HttpErrorHandlerEntity> httpErrorsHandlingEntries = getHttpErrorHandlingEntries();
       boolean supportsSkippingPages = PaginationIteratorFactory
         .createInstance(this, null).supportsSkippingPages();
@@ -740,8 +740,9 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
           propertiesShouldBeNotNull.put(PROPERTY_INDEX_INCREMENT,
                                         propertiesShouldBeNull.remove(PROPERTY_INDEX_INCREMENT));
           propertiesShouldBeNull.remove(PROPERTY_MAX_INDEX); // can be both null and non null
-
-          if (!url.contains(PAGINATION_INDEX_PLACEHOLDER)) {
+          
+          // fix: defer validation at runtime, when url contains a macro
+          if (!containsMacro(PROPERTY_URL) && !url.contains(PAGINATION_INDEX_PLACEHOLDER)) {
             throw new InvalidConfigPropertyException(
               String.format("Url '%s' must contain '%s' placeholder when pagination type is '%s'", getUrl(),
                             PAGINATION_INDEX_PLACEHOLDER, getPaginationType()),


### PR DESCRIPTION
fix: defer validation at runtime, when url contains a macro avoiding NullPointerExceptions