### PR TITLE
add the capacity to parse a JSON Object or JSON Array as a string in HTTP source plugins

### DIFF
--- a/docs/HTTP-batchsource.md
+++ b/docs/HTTP-batchsource.md
@@ -203,6 +203,10 @@ can be omitted as long as the field is present in schema.
 
 **CSV Skip First Row:** Whether to skip the first row of the HTTP response. This is usually set if the first row is a header row.
 
+**Authorize Parsing of Objects to String:** Whether to allow the parsing of JSON Objects/Arrays to string.
+If set to true, every JSON Objects/Arrays in the record will be parsed as a string field if defined as string in the output schema.
+This option can be used to handle JSON that contain fields with dynamically changing schema
+
 ### Basic Authentication
 
 **Username:** Username for basic authentication.

--- a/docs/HTTP-streamingsource.md
+++ b/docs/HTTP-streamingsource.md
@@ -207,6 +207,10 @@ can be omitted as long as the field is present in schema.
 
 **CSV Skip First Row:** Whether to skip the first row of the HTTP response. This is usually set if the first row is a header row.
 
+**Authorize Parsing of Objects to String:** Whether to allow the parsing of JSON Objects/Arrays to string.
+If set to true, every JSON Objects/Arrays in the record will be parsed as a string field if defined as string in the output schema.
+This option can be used to handle JSON that contain fields with dynamically changing schema
+
 ### Basic Authentication
 
 **Username:** Username for basic authentication.

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -98,6 +98,7 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   public static final String PROPERTY_TRUSTSTORE_KEY_ALGORITHM = "trustStoreKeyAlgorithm";
   public static final String PROPERTY_TRANSPORT_PROTOCOLS = "transportProtocols";
   public static final String PROPERTY_CIPHER_SUITES = "cipherSuites";
+  public static final String PROPERTY_AUTHORIZE_OBJECT_PARSING_TO_STRING = "authorizeParsingOfObjectToString";
   public static final String PROPERTY_SCHEMA = "schema";
 
   public static final String PAGINATION_INDEX_PLACEHOLDER_REGEX = "\\{pagination.index\\}";
@@ -384,6 +385,12 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   @Macro
   protected String cipherSuites;
 
+  @Name(PROPERTY_AUTHORIZE_OBJECT_PARSING_TO_STRING)
+  @Description("If set to true, the JSON Arrays and JSON Objects in data can be retrieved as strings field " +
+          "(if set as string in the output schema). This can be used to handle JSONs with dynamic schema. ")
+  @Macro
+  protected String authorizeParsingOfObjectToString;
+
   @Name(PROPERTY_SCHEMA)
   @Macro
   @Nullable
@@ -615,6 +622,10 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   @Nullable
   public String getCipherSuites() {
     return cipherSuites;
+  }
+
+  public Boolean isParsingOfObjectToStringEnabled() {
+    return Boolean.parseBoolean(authorizeParsingOfObjectToString);
   }
 
   @Nullable

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -99,6 +99,22 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Authorize Parsing of Objects to String",
+          "name": "authorizeParsingOfObjectToString",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "label": "True",
+              "value": "true"
+            },
+            "off": {
+              "label": "False",
+              "value": "false"
+            }
+          }
         }
       ]
     },
@@ -662,6 +678,20 @@
         },
         {
           "name": "fieldsMapping",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "JSON Formatting",
+      "condition": {
+        "property": "format",
+        "operator": "equal to",
+        "value": "json"
+      },
+      "show": [
+        {
+          "name": "authorizeParsingOfObjectToString",
           "type": "property"
         }
       ]

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -104,6 +104,22 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "toggle",
+          "label": "Authorize Parsing of Objects to String",
+          "name": "authorizeParsingOfObjectToString",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "label": "True",
+              "value": "true"
+            },
+            "off": {
+              "label": "False",
+              "value": "false"
+            }
+          }
         }
       ]
     },
@@ -662,6 +678,20 @@
         },
         {
           "name": "fieldsMapping",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "JSON Formatting",
+      "condition": {
+        "property": "format",
+        "operator": "equal to",
+        "value": "json"
+      },
+      "show": [
+        {
+          "name": "authorizeParsingOfObjectToString",
           "type": "property"
         }
       ]


### PR DESCRIPTION
Some APIs might return JSON data with dynamically changing schema for some fields. Today, HTTP Source plugins are not able to handle this kind of data. 

For example, in the following [google API](https://developers.google.com/admin-sdk/directory/reference/rest/v1/users#User) , the field 'customSchema' might have a changing schema.

This pull request add the capacity to parse a JSON object/array to a stringify value.

Here is an example : 

Considering the following input data : 

```
{
	"someField":"someValue",
	"customSchema":{
		"customInnerField1":"innerValue1",
		"customInnerField2":"innerValue2",
		"customInnerField3":"innerValue3"
	},
	"someObject":{
		"someId":"someValue",
		"someType":"someValue"
	}
}
```

Where 'customSchema' might contain a large and unknown number of 'customInnerField'.

With this new feature, the plugin can handle this data if the configuration field 'Authorize Parsing of Objects to String' is set to True, and the field 'customSchema' is defined as STRING in the output schema.

The output record would then be : 

```
{
	"someField":"someValue",
	"customSchema":"{\"customInnerField1\":\"innerValue1\",\"customInnerField2\":\"innerValue2\",\"customInnerField3\":\"innerValue3\"}",
	"someObject":{
		"someId":"someValue",
		"someType":"someValue"
	}
}
```








