### PR TITLE
Add Service Account authentication for HTTP Source Plugins

### DIFF
--- a/docs/HTTP-batchsource.md
+++ b/docs/HTTP-batchsource.md
@@ -374,6 +374,14 @@ def get_next_page_url(url, page, headers):
 The above code iterates over first five pages of searchcode.com results. When 'None' is returned the iteration
 is stopped.
 
+### Service Account
+
+**Service Account Enabled:** If true, plugin will perform OAuth2 authentication.
+
+**JSON Private Key:** The JSON Private Key of the Service Account.
+
+**Scopes:** Scope of the access request, which might have multiple space-separated values.
+
 ### OAuth2
 
 **OAuth2 Enabled:** If true, plugin will perform OAuth2 authentication.

--- a/docs/HTTP-streamingsource.md
+++ b/docs/HTTP-streamingsource.md
@@ -381,6 +381,14 @@ def get_next_page_url(url, page, headers):
 The above code iterates over first five pages of searchcode.com results. When 'None' is returned the iteration
 is stopped.
 
+### Service Account
+
+**Service Account Enabled:** If true, plugin will perform OAuth2 authentication.
+
+**JSON Private Key:** The JSON Private Key of the Service Account.
+
+**Scopes:** Scope of the access request, which might have multiple space-separated values.
+
 ### OAuth2
 
 **OAuth2 Enabled:** If true, plugin will perform OAuth2 authentication.

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
     <spark2.version>2.1.3</spark2.version>
     <unxml.version>0.9</unxml.version>
     <wiremock.version>1.49</wiremock.version>
+    <google.auth.version>0.25.5</google.auth.version>
   </properties>
 
   <dependencies>
@@ -354,7 +355,17 @@
       <artifactId>jython-standalone</artifactId>
       <version>${jython.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+      <version>${google.auth.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <!-- tests -->
     <dependency>

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -87,6 +87,9 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   public static final String PROPERTY_CLIENT_SECRET = "clientSecret";
   public static final String PROPERTY_SCOPES = "scopes";
   public static final String PROPERTY_REFRESH_TOKEN = "refreshToken";
+  public static final String PROPERTY_SERVICE_ACCOUNT_ENABLED = "serviceAccountEnabled";
+  public static final String PROPERTY_SERVICE_ACCOUNT_SCOPE = "serviceAccountScopes";
+  public static final String PROPERTY_SERVICE_ACCOUNT_PRIVATE_KEY_JSON = "serviceAccountPrivateKeyJson";
   public static final String PROPERTY_VERIFY_HTTPS = "verifyHttps";
   public static final String PROPERTY_KEYSTORE_FILE = "keystoreFile";
   public static final String PROPERTY_KEYSTORE_TYPE = "keystoreType";
@@ -315,6 +318,22 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   @Description("Token used to receive accessToken, which is end product of OAuth2.")
   @Macro
   protected String refreshToken;
+
+  @Name(PROPERTY_SERVICE_ACCOUNT_ENABLED)
+  @Description("If true, plugin will perform service account authentication.")
+  protected String serviceAccountEnabled;
+
+  @Nullable
+  @Name(PROPERTY_SERVICE_ACCOUNT_SCOPE)
+  @Description("The scope used to retrieve service account access token")
+  @Macro
+  protected String serviceAccountScope;
+
+  @Nullable
+  @Name(PROPERTY_SERVICE_ACCOUNT_PRIVATE_KEY_JSON)
+  @Description("Service account json private key")
+  @Macro
+  protected String serviceAccountPrivateKeyJson;
 
   @Name(PROPERTY_VERIFY_HTTPS)
   @Description("If false, untrusted trust certificates (e.g. self signed), will not lead to an" +
@@ -563,6 +582,20 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
     return refreshToken;
   }
 
+  public boolean getServiceAccountEnabled() {
+    return Boolean.parseBoolean(serviceAccountEnabled);
+  }
+
+  @Nullable
+  public String getServiceAccountScope() {
+    return serviceAccountScope;
+  }
+
+  @Nullable
+  public String getServiceAccountPrivateKeyJson() {
+    return serviceAccountPrivateKeyJson;
+  }
+
   public Boolean getVerifyHttps() {
     return Boolean.parseBoolean(verifyHttps);
   }
@@ -792,6 +825,13 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
       assertIsSet(getClientId(), PROPERTY_CLIENT_ID, reasonOauth2);
       assertIsSet(getClientSecret(), PROPERTY_CLIENT_SECRET, reasonOauth2);
       assertIsSet(getRefreshToken(), PROPERTY_REFRESH_TOKEN, reasonOauth2);
+    }
+
+    // Validate service account auth properties
+    if (!containsMacro(PROPERTY_SERVICE_ACCOUNT_PRIVATE_KEY_JSON) && this.getServiceAccountEnabled()) {
+      String reasonSA = "Service Account Authentication is enabled";
+      //assertIsSet(getServiceAccountScope(), PROPERTY_SERVICE_ACCOUNT_SCOPE, reasonSA);
+      assertIsSet(getServiceAccountPrivateKeyJson(), PROPERTY_SERVICE_ACCOUNT_PRIVATE_KEY_JSON, reasonSA);
     }
 
     if (!containsMacro(PROPERTY_VERIFY_HTTPS) && !getVerifyHttps()) {

--- a/src/main/java/io/cdap/plugin/http/source/common/http/ServiceAccountTokenHandler.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/http/ServiceAccountTokenHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.http.source.common.http;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import javax.security.sasl.AuthenticationException;
+
+/**
+ * Handle Service Account tokens
+ */
+public class ServiceAccountTokenHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceAccountTokenHandler.class);
+
+    private AccessToken token;
+    GoogleCredentials googleCredentials;
+
+    public ServiceAccountTokenHandler(String scopes, String privateKeyJson) throws IOException {
+        ServiceAccountCredentials serviceAccountCredentials;
+
+        try (InputStream stream = new ByteArrayInputStream(privateKeyJson.getBytes())) {
+            serviceAccountCredentials = ServiceAccountCredentials.fromStream(stream);
+        }
+
+        googleCredentials = serviceAccountCredentials
+                .createScoped(scopes.split(" "));
+    }
+
+    public boolean tokenExpireSoon() {
+        if (token == null) {
+            return true;
+        }
+        Date currentDate = new Date();
+        Date expirationTime = token.getExpirationTime();
+        Date expirationTimeShifted = new Date(expirationTime.getTime() - (5 * 60 * 1000));
+        // Remove 5 minutes from the expiration date for more safety
+
+        return currentDate.after(expirationTimeShifted);
+    }
+
+    public AccessToken getAccessToken() throws IOException {
+        if (token == null) {
+            token = googleCredentials.getAccessToken();
+
+            if (token == null) {
+                token = googleCredentials.refreshAccessToken();
+            }
+        } else {
+            if (tokenExpireSoon()) {
+                token = googleCredentials.refreshAccessToken();
+            }
+        }
+
+        if (token != null) {
+            return token;
+        } else {
+            throw new AuthenticationException("Tried to get access token from GoogleCrendentials but got " + token);
+        }
+    }
+}

--- a/src/test/java/io/cdap/plugin/http/etl/BaseHttpBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/http/etl/BaseHttpBatchSourceETLTest.java
@@ -87,6 +87,7 @@ public abstract class BaseHttpBatchSourceETLTest extends HydratorTestBase {
       .put("referenceName", name.getMethodName())
       .put(BaseHttpSourceConfig.PROPERTY_HTTP_METHOD, "GET")
       .put(BaseHttpSourceConfig.PROPERTY_OAUTH2_ENABLED, "false")
+      .put(BaseHttpSourceConfig.PROPERTY_SERVICE_ACCOUNT_ENABLED, "false")
       .put(BaseHttpSourceConfig.PROPERTY_HTTP_ERROR_HANDLING, "2..:Success,.*:Fail")
       .put(BaseHttpSourceConfig.PROPERTY_ERROR_HANDLING, "stopOnError")
       .put(BaseHttpSourceConfig.PROPERTY_RETRY_POLICY, "linear")

--- a/src/test/java/io/cdap/plugin/http/etl/HttpSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/http/etl/HttpSourceETLTest.java
@@ -487,6 +487,7 @@ public abstract class HttpSourceETLTest extends HydratorTestBase {
       .put("referenceName", testName.getMethodName())
       .put(BaseHttpSourceConfig.PROPERTY_HTTP_METHOD, "GET")
       .put(BaseHttpSourceConfig.PROPERTY_OAUTH2_ENABLED, "false")
+      .put(BaseHttpSourceConfig.PROPERTY_SERVICE_ACCOUNT_ENABLED, "false")
       .put(BaseHttpSourceConfig.PROPERTY_HTTP_ERROR_HANDLING, "2..:Success,.*:Fail")
       .put(BaseHttpSourceConfig.PROPERTY_ERROR_HANDLING, "stopOnError")
       .put(BaseHttpSourceConfig.PROPERTY_RETRY_POLICY, "linear")

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -103,6 +103,37 @@
       ]
     },
     {
+      "label": "Service Account Authentication",
+      "properties": [
+        {
+          "widget-type": "toggle",
+          "label": "Service Account Enabled",
+          "name": "serviceAccountEnabled",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "label": "True",
+              "value": "true"
+            },
+            "off": {
+              "label": "False",
+              "value": "false"
+            }
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "JSON Private Key",
+          "name": "serviceAccountPrivateKeyJson"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Scopes",
+          "name": "serviceAccountScopes"
+        }
+      ]
+    },
+    {
       "label": "OAuth2",
       "properties": [
         {
@@ -599,19 +630,19 @@
       ]
     },
     {
-      "name": "OAuth 2 disabled",
+      "name": "Service Account enabled",
       "condition": {
-        "property": "oauth2Enabled",
+        "property": "serviceAccountEnabled",
         "operator": "equal to",
-        "value": "false"
+        "value": "true"
       },
       "show": [
         {
-          "name": "username",
+          "name": "serviceAccountPrivateKeyJson",
           "type": "property"
         },
         {
-          "name": "password",
+          "name": "serviceAccountScopes",
           "type": "property"
         }
       ]

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -108,6 +108,37 @@
       ]
     },
     {
+      "label": "Service Account Authentication",
+      "properties": [
+        {
+          "widget-type": "toggle",
+          "label": "Service Account Enabled",
+          "name": "serviceAccountEnabled",
+          "widget-attributes": {
+            "default": "false",
+            "on": {
+              "label": "True",
+              "value": "true"
+            },
+            "off": {
+              "label": "False",
+              "value": "false"
+            }
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "JSON Private Key",
+          "name": "serviceAccountPrivateKeyJson"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Scopes",
+          "name": "serviceAccountScopes"
+        }
+      ]
+    },
+    {
       "label": "OAuth2",
       "properties": [
         {
@@ -599,19 +630,19 @@
       ]
     },
     {
-      "name": "OAuth 2 disabled",
+      "name": "Service Account enabled",
       "condition": {
-        "property": "oauth2Enabled",
+        "property": "serviceAccountEnabled",
         "operator": "equal to",
-        "value": "false"
+        "value": "true"
       },
       "show": [
         {
-          "name": "username",
+          "name": "serviceAccountPrivateKeyJson",
           "type": "property"
         },
         {
-          "name": "password",
+          "name": "serviceAccountScopes",
           "type": "property"
         }
       ]


### PR DESCRIPTION
This PR adds the capability to use Service Account as an authentication method for HTTP Source Plugins. 