### PR TITLE
Fix Wait Time Between Pages feature

### DIFF
--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -585,20 +585,6 @@
       ]
     },
     {
-      "name": "Pagination none",
-      "condition": {
-        "property": "paginationType",
-        "operator": "equal to",
-        "value": "None"
-      },
-      "show": [
-        {
-          "name": "waitTimeBetweenPages",
-          "type": "property"
-        }
-      ]
-    },
-    {
       "name": "OAuth 2 disabled",
       "condition": {
         "property": "oauth2Enabled",

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -588,7 +588,7 @@
       "name": "Pagination none",
       "condition": {
         "property": "paginationType",
-        "operator": "equal to",
+        "operator": "not equal to",
         "value": "None"
       },
       "show": [

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -585,6 +585,20 @@
       ]
     },
     {
+      "name": "Pagination none",
+      "condition": {
+        "property": "paginationType",
+        "operator": "not equal to",
+        "value": "None"
+      },
+      "show": [
+        {
+          "name": "waitTimeBetweenPages",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "OAuth 2 disabled",
       "condition": {
         "property": "oauth2Enabled",

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -585,20 +585,6 @@
       ]
     },
     {
-      "name": "Pagination none",
-      "condition": {
-        "property": "paginationType",
-        "operator": "equal to",
-        "value": "None"
-      },
-      "show": [
-        {
-          "name": "waitTimeBetweenPages",
-          "type": "property"
-        }
-      ]
-    },
-    {
       "name": "OAuth 2 disabled",
       "condition": {
         "property": "oauth2Enabled",

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -588,7 +588,7 @@
       "name": "Pagination none",
       "condition": {
         "property": "paginationType",
-        "operator": "equal to",
+        "operator": "not equal to",
         "value": "None"
       },
       "show": [

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -585,6 +585,20 @@
       ]
     },
     {
+      "name": "Pagination none",
+      "condition": {
+        "property": "paginationType",
+        "operator": "not equal to",
+        "value": "None"
+      },
+      "show": [
+        {
+          "name": "waitTimeBetweenPages",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "OAuth 2 disabled",
       "condition": {
         "property": "oauth2Enabled",


### PR DESCRIPTION
The "Wait Time Between Pages" configuration for HTTP sources was visible in configuration widget only when pagination was disabled.

It is now visible when pagination is enabled.