### PR TITLE
Add possibility to use particular certificate for client during 2 way ssl connection

### DIFF
--- a/docs/HTTP-batchsource.md
+++ b/docs/HTTP-batchsource.md
@@ -403,6 +403,20 @@ error. Do not disable this in production environment on a network you do not ent
 
 **Keystore Key Algorithm:** An algorithm used for keystore.
 
+**Keystore Cert Alias**
+
+ Alias of the key in the keystore to be used for communication. This options is supported only by X.509 keys or keystores.
+ 
+Below is an example how the store need to be prepared:
+ ```
+ cat  client.crt client.key > client-bundle.pem
+
+ openssl pkcs12 -export -in client-bundle.pem -out full-chain.keycert.p12 -name ${CERT_ALIAS}
+
+ keytool -importkeystore -srckeystore full-chain.keycert.p12 -srcstoretype pkcs12 -srcalias ${CERT_ALIAS} \
+                         -destkeystore identity.jks -deststoretype jks -destalias ${CERT_ALIAS}
+ ```
+
 **TrustStore File:** A path to a file which contains truststore.
 
 **TrustStore Type:** Format of a truststore.

--- a/docs/HTTP-streamingsource.md
+++ b/docs/HTTP-streamingsource.md
@@ -410,6 +410,20 @@ error. Do not disable this in production environment on a network you do not ent
 
 **Keystore Key Algorithm:** An algorithm used for keystore.
 
+**Keystore Cert Alias**
+
+Alias of the key in the keystore to be used for communication. This options is supported only by X.509 keys or keystores.
+
+Below is an example how the store need to be prepared:
+ ```
+ cat  client.crt client.key > client-bundle.pem
+
+ openssl pkcs12 -export -in client-bundle.pem -out full-chain.keycert.p12 -name ${CERT_ALIAS}
+
+ keytool -importkeystore -srckeystore full-chain.keycert.p12 -srcstoretype pkcs12 -srcalias ${CERT_ALIAS} \
+                         -destkeystore identity.jks -deststoretype jks -destalias ${CERT_ALIAS}
+ ```
+
 **TrustStore File:** A path to a file which contains truststore.
 
 **TrustStore Type:** Format of a truststore.

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.1-SNAPSHOT</version>
 
   <licenses>
     <license>
@@ -79,10 +79,12 @@
     <cdap.version>6.1.1</cdap.version>
     <commons.version>3.9</commons.version>
     <common.codec.version>1.12</common.codec.version>
+    <common.logging.version>1.2</common.logging.version>
+    <log4j.version>1.2.17</log4j.version>
     <gson.version>2.8.5</gson.version>
     <hadoop.version>2.3.0</hadoop.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>
-    <hydrator.version>2.4.0-SNAPSHOT</hydrator.version>
+    <hydrator.version>2.4.0</hydrator.version>
     <jackson.version>2.9.9</jackson.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.7.1</jython.version>
@@ -93,6 +95,20 @@
   </properties>
 
   <dependencies>
+    <!-- Required to work properly on external hadoop clusters-->
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>${common.logging.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+     <groupId>log4j</groupId>
+     <artifactId>log4j</artifactId>
+     <version>${log4j.version}</version>
+     <scope>compile</scope>
+    </dependency>
+    <!-- / end required -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api</artifactId>

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -100,6 +100,8 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   public static final String PROPERTY_CIPHER_SUITES = "cipherSuites";
   public static final String PROPERTY_SCHEMA = "schema";
 
+  public static final String PROPERTY_KEYSTORE_CERT_ALIAS = "keystoreCertAlias";
+
   public static final String PAGINATION_INDEX_PLACEHOLDER_REGEX = "\\{pagination.index\\}";
   public static final String PAGINATION_INDEX_PLACEHOLDER = "{pagination.index}";
 
@@ -390,6 +392,12 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
   @Description("Output schema. Is required to be set.")
   protected String schema;
 
+  @Name(PROPERTY_KEYSTORE_CERT_ALIAS)
+  @Macro
+  @Nullable
+  @Description("Alias of the key in the keystore to be used for communication")
+  protected String keystoreCertAliasName;
+
   protected BaseHttpSourceConfig(String referenceName) {
     super(referenceName);
   }
@@ -625,6 +633,11 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
       throw new InvalidConfigPropertyException("Unable to parse output schema: " +
                                                  schema, e, PROPERTY_SCHEMA);
     }
+  }
+
+  @Nullable
+  public String getKeystoreCertAliasName() {
+    return keystoreCertAliasName;
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/http/source/common/http/X509KeyManagerAliasWrapper.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/http/X509KeyManagerAliasWrapper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright ┬⌐ 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.http.source.common.http;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.X509KeyManager;
+
+
+/**
+ * This is just wrapper over SunX509KeyManagerImpl with possibility to provide specific alias
+ *
+ * Usage example:
+ *    X509KeyManagerAliasWrapper.getKeyManagers(keyManagerFactory, CERT_ALIAS);
+ */
+public class X509KeyManagerAliasWrapper implements X509KeyManager  {
+
+  private final X509KeyManager originalKeyManager;
+  private final String certAlias;
+
+  public X509KeyManagerAliasWrapper(X509KeyManager originalKeyManager, String certAlias) {
+    this.originalKeyManager = originalKeyManager;
+    this.certAlias = certAlias;
+  }
+
+  public static KeyManager[] getKeyManagers(KeyManagerFactory keyManagerFactory, String certAlias) {
+    KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+
+    // Current implementation only support X509 Certificates
+    if (keyManagers.length != 1) {
+      return keyManagers;
+    }
+    if (!(keyManagers[0] instanceof X509KeyManager)) {
+      return keyManagers;
+    }
+
+   return new KeyManager[]{ new X509KeyManagerAliasWrapper((X509KeyManager) keyManagers[0], certAlias) };
+ };
+
+  @Override
+  public String chooseClientAlias(String[] strings, Principal[] principals, Socket socket) {
+    return certAlias;
+  }
+
+  @Override
+  public String[] getClientAliases(String s, Principal[] principals) {
+    return originalKeyManager.getClientAliases(s, principals);
+  }
+
+  @Override
+  public String[] getServerAliases(String s, Principal[] principals) {
+    return originalKeyManager.getServerAliases(s, principals);
+  }
+
+  @Override
+  public String chooseServerAlias(String s, Principal[] principals, Socket socket) {
+    return originalKeyManager.chooseServerAlias(s, principals, socket);
+  }
+
+  @Override
+  public X509Certificate[] getCertificateChain(String s) {
+    return originalKeyManager.getCertificateChain(s);
+  }
+
+  @Override
+  public PrivateKey getPrivateKey(String s) {
+    return originalKeyManager.getPrivateKey(s);
+  }
+}

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -428,6 +428,11 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Keystore Cert Alias",
+          "name": "keystoreCertAlias"
+        },
+        {
+          "widget-type": "textbox",
           "label": "TrustStore File",
           "name": "trustStoreFile"
         },

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -427,6 +427,11 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Keystore Cert Alias",
+          "name": "keystoreCertAlias"
+        },
+        {
+          "widget-type": "textbox",
           "label": "TrustStore File",
           "name": "trustStoreFile"
         },


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/PLUGIN-1008

**The issue:**
In some cases, java struggling to  auto-detect the proper client certificate for the 2-way SSL connection in the truststore, especially if the certificate contains custom constraints.  It prevents plugin to establish a secure 2 way ssl connection

**What need to be done:**
In such cases - http plugin should provide possibility to ask user for specific certificate alias in the keystore, to use it later for client connection instead of trying to auto-detect it

**What was done:**
- Added new configuration item for the plugin - "Keystore Cert Alias"
- In case, if user set the alias for certificate, plugin would try to use it, instead of trying to auto-detect
- The feature is supported only for X.509 keystores/certificates

Unit tests passed:
```
Results :

Tests run: 41, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:48 min
[INFO] Finished at: 2021-12-14T15:02:38+02:00
[INFO] ------------------------------------------------------------------------
```