### PR TITLE
Fix "Increment an Index" pagination for HTTP Source plugin

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -683,7 +683,7 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
     }
 
     // Validate HTTP Error Handling Map
-    if (!containsMacro(PROPERTY_HTTP_ERROR_HANDLING)) {
+    if (!containsMacro(PROPERTY_HTTP_ERROR_HANDLING) && !containsMacro(PROPERTY_URL)) {
       List<HttpErrorHandlerEntity> httpErrorsHandlingEntries = getHttpErrorHandlingEntries();
       boolean supportsSkippingPages = PaginationIteratorFactory
         .createInstance(this, null).supportsSkippingPages();
@@ -741,7 +741,7 @@ public abstract class BaseHttpSourceConfig extends ReferencePluginConfig {
                                         propertiesShouldBeNull.remove(PROPERTY_INDEX_INCREMENT));
           propertiesShouldBeNull.remove(PROPERTY_MAX_INDEX); // can be both null and non null
 
-          if (!url.contains(PAGINATION_INDEX_PLACEHOLDER)) {
+          if (!containsMacro(PROPERTY_URL) && !url.contains(PAGINATION_INDEX_PLACEHOLDER)) {
             throw new InvalidConfigPropertyException(
               String.format("Url '%s' must contain '%s' placeholder when pagination type is '%s'", getUrl(),
                             PAGINATION_INDEX_PLACEHOLDER, getPaginationType()),


### PR DESCRIPTION
In the HTTP source plugin, if the URL contains a macro, and the pagination type is set as "Increment an Index", the plugin's configuration validation fails with a Null Pointer Exception.

This PR fixes this bug by cancelling URL validation when URL contains macro. 
