### PR TITLE
[PLUGIN-826] skip some validations when url contains macro

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.plugin.http.source.batch;
 
+import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
 
 /**
@@ -23,6 +24,11 @@ import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
 public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
   protected HttpBatchSourceConfig(String referenceName) {
     super(referenceName);
+  }
+
+  @Override
+  public void validate(FailureCollector failureCollector) {
+    super.validate(failureCollector);
   }
 
   private HttpBatchSourceConfig(HttpBatchSourceConfigBuilder builder) {


### PR DESCRIPTION
# [PLUGIN-826] skip some validations when url contains macro

## Description
Currently when the url contains a macro that will get evaluated at runtime, validation will throw error since the url will get a null value. Hence skipping the validations that required the url when the url contains macro.

[PLUGIN-826](https://cdap.atlassian.net/browse/PLUGIN-826)