### PR TITLE
[CDAP-20012] Adding support for missing keys in http plugin and adding some error …

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/common/pagination/page/InvalidEntryCreator.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/pagination/page/InvalidEntryCreator.java
@@ -41,8 +41,12 @@ public class InvalidEntryCreator {
   }
 
   public static InvalidEntry<StructuredRecord> buildStringError(String recordBody, Throwable e) {
-    String errorText = String.format("Cannot convert line '%s' to a record. Reason: '%s: %s'",
-                                     recordBody, e.getClass().getName(), e.getMessage());
+    return buildStringError(recordBody, "", e);
+  }
+
+  public static InvalidEntry<StructuredRecord> buildStringError(String recordBody, String actionText, Throwable e) {
+    String errorText = String.format("Cannot convert line '%s' to a record. Reason: '%s: %s'. %s",
+                                     recordBody, e.getClass().getName(), e.getMessage(), actionText);
 
     return buildStringError(0, recordBody, errorText);
   }

--- a/src/main/java/io/cdap/plugin/http/source/common/pagination/page/JSONUtil.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/pagination/page/JSONUtil.java
@@ -70,12 +70,21 @@ public class JSONUtil {
         jsonObject = currentElement.getAsJsonObject();
       }
 
-      if (!currentElement.isJsonObject() || jsonObject.get(pathPart) == null) {
+      if (!currentElement.isJsonObject()) {
         return new JsonQueryResponse(
           Arrays.copyOfRange(pathParts, 0, i),
           Arrays.copyOfRange(pathParts, i, pathParts.length),
           optionalFields,
           currentElement
+        );
+      }
+
+      if (jsonObject.get(pathPart) == null) {
+        return new JsonQueryResponse(
+          Arrays.copyOfRange(pathParts, 0, i),
+          Arrays.copyOfRange(pathParts, i, pathParts.length),
+          optionalFields,
+          null
         );
       }
 

--- a/src/main/java/io/cdap/plugin/http/source/common/pagination/page/JsonPage.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/pagination/page/JsonPage.java
@@ -166,6 +166,10 @@ class JsonPage extends BasePage {
         return new PageEntry(error, config.getErrorHandling());
       }
       return new PageEntry(record);
+    } catch (IllegalStateException e) {
+      return new PageEntry(InvalidEntryCreator.buildStringError(
+        jsonString, "Check if the field should be set to Nullable in the output schema.", e),
+                           config.getErrorHandling());
     } catch (Throwable e) {
       return new PageEntry(InvalidEntryCreator.buildStringError(jsonString, e), config.getErrorHandling());
     }

--- a/src/test/java/io/cdap/plugin/http/source/common/pagination/page/JSONUtilTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/pagination/page/JSONUtilTest.java
@@ -80,6 +80,16 @@ public class JSONUtilTest {
   }
 
   @Test
+  public void testRetrieveMissing() {
+    JsonObject jsonObject = JSONUtil.toJsonObject(JSON);
+    JSONUtil.JsonQueryResponse response = JSONUtil.getJsonElementByPath(jsonObject, "/missingField",
+                                                                        new ArrayList<>());
+    Assert.assertEquals("/", response.getRetrievedPath());
+    Assert.assertEquals("/missingField", response.getUnretrievedPath());
+    Assert.assertEquals(null, response.get());
+  }
+
+  @Test
   public void testRetrievePrimitive() {
     JsonObject jsonObject = JSONUtil.toJsonObject(JSON);
     JSONUtil.JsonQueryResponse response = JSONUtil.getJsonElementByPath(jsonObject, "/pageInfo/totalResults",


### PR DESCRIPTION
Bug: https://cdap.atlassian.net/browse/CDAP-20012

The customer was facing the issue that if there is a missing non-nullable field in the HTTP plugin, they get an error stating `No matching schema found`. Instead they wanted the missing fields to get interpreted as null in the output schema fields.

The root cause of the issue is: The input fields of the plugin are converted to JsonObject. If there is a missing field, a partial json path to the field is retrieved. The proposed change instead returns a null object for that missing field.

Also added some error logs for suggesting user to set the `nullable` option in the case when there is a missing field in the input schema and nullable is not set.