### PR TITLE
Fix Regex error in the Http Sink

### DIFF
--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSink.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSink.java
@@ -70,7 +70,7 @@ import javax.net.ssl.X509TrustManager;
 public class HTTPSink extends BatchSink<StructuredRecord, Void, Void> {
 
   private static final Logger LOG = LoggerFactory.getLogger(HTTPSink.class);
-  private static final String REGEX_HASHED_VAR = "#s*(\\w+)";
+  private static final String REGEX_HASHED_VAR = "#(\\w+)";
 
   private static StringBuilder messages = new StringBuilder();
   private String contentType;


### PR DESCRIPTION
When we set any input in the input schema starting with the "s", it results in the error. As "s" gets excluded from the group(1).