### PR TITLE
[PLUGIN-1447] Creating the buffered reader only when iterating over the pages.

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/common/pagination/page/RecordPerLinePage.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/pagination/page/RecordPerLinePage.java
@@ -29,17 +29,16 @@ import java.util.NoSuchElementException;
  * Returns every row of document as a structured record.
  */
 abstract class RecordPerLinePage extends BasePage {
-  private final BufferedReader bufferedReader;
+  private BufferedReader bufferedReader;
   protected final Schema schema;
   protected final BaseHttpSourceConfig config;
   protected boolean isLineRead;
   private String lastLine;
 
-  RecordPerLinePage(BaseHttpSourceConfig config, HttpResponse httpResponse) throws IOException {
+  RecordPerLinePage(BaseHttpSourceConfig config, HttpResponse httpResponse) {
     super(httpResponse);
     this.config = config;
     this.schema = config.getSchema();
-    this.bufferedReader = new BufferedReader(new InputStreamReader(httpResponse.getInputStream()));
   }
 
   @Override
@@ -49,11 +48,18 @@ abstract class RecordPerLinePage extends BasePage {
                                                           config.getFormat()));
   }
 
+  private BufferedReader getBufferedReader() throws IOException {
+    if (bufferedReader == null) {
+      this.bufferedReader = new BufferedReader(new InputStreamReader(httpResponse.getInputStream()));
+    }
+    return bufferedReader;
+  }
+
   @Override
   public boolean hasNext() {
     try {
       if (!isLineRead) {
-        lastLine = this.bufferedReader.readLine();
+        lastLine = this.getBufferedReader().readLine();
       }
       isLineRead = true;
       return lastLine != null;

--- a/src/test/java/io/cdap/plugin/http/source/common/pagination/RecordsPerLinesPageTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/pagination/RecordsPerLinesPageTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.source.common.pagination;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.Schema.Field;
+import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
+import io.cdap.plugin.http.source.common.http.HttpResponse;
+import io.cdap.plugin.http.source.common.pagination.page.BasePage;
+import io.cdap.plugin.http.source.common.pagination.page.PageFactory;
+import io.cdap.plugin.http.source.common.pagination.page.PageFormat;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.util.LinkedList;
+
+public class RecordsPerLinesPageTest {
+
+  @Test
+  public void testPageIterationMechanism () throws Exception {
+    CloseableHttpResponse clResponse = Mockito.mock(CloseableHttpResponse.class);
+    HttpResponse response = new HttpResponse(clResponse);
+    BaseHttpSourceConfig config = Mockito.mock(BaseHttpSourceConfig.class);
+    Mockito.when(config.getFormat()).thenReturn(PageFormat.TEXT);
+    LinkedList sampleField = new LinkedList<Field>();
+    sampleField.add(Field.of("output", Schema.of(Schema.Type.STRING)));
+    Schema schema = Schema.recordOf("inputSchema", sampleField);
+    Mockito.when(config.getSchema()).thenReturn(schema);
+    BasePage page = PageFactory.createInstance(config, response, null, false);
+    String testString = "This is a test string.";
+    byte[] testBytes = testString.getBytes();
+    HttpEntity httpEntity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpEntity.getContent()).thenReturn(new ByteArrayInputStream(testBytes));
+    Mockito.when(clResponse.getEntity()).thenReturn(httpEntity);
+    Assert.assertEquals(testString, response.getBody());
+    if (page.hasNext()) {
+      String actualString = page.next().getRecord().get("output");
+      Assert.assertTrue(testString.equals(actualString));
+    }
+  }
+}


### PR DESCRIPTION
Jira link : https://cdap.atlassian.net/browse/PLUGIN-1447
The BufferedReader is created lazily, to make sure that an opened stream is used to iterate the page.

Validations:
1. Along with custom pagination logic the page iteration works as expected.
2. In case of Text page without pagination the page iteration works as expected.