### PR TITLE
[PLUGIN-1577] Changed the logic to use HttpHost constructor for creating AuthScope

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/common/http/HttpClient.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/http/HttpClient.java
@@ -107,7 +107,8 @@ public class HttpClient implements Closeable {
     // basic auth
     CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     if (!Strings.isNullOrEmpty(config.getUsername()) && !Strings.isNullOrEmpty(config.getPassword())) {
-      AuthScope authScope = new AuthScope(HttpHost.create(config.getUrl()));
+      URI uri = URI.create(config.getUrl());
+      AuthScope authScope = new AuthScope(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()));
       credentialsProvider.setCredentials(authScope,
                                          new UsernamePasswordCredentials(config.getUsername(), config.getPassword()));
     }


### PR DESCRIPTION
Changed the logic to use HttpHost constructor for creating auth scope in place of its create method.
Cherry-pick : https://github.com/data-integrations/http/pull/113
JIRA : https://cdap.atlassian.net/browse/PLUGIN-1577