### PR TITLE
[PLUGIN-1676] Added Json batch support in HTTP sink

### DIFF
--- a/docs/HTTP-batchsink.md
+++ b/docs/HTTP-batchsink.md
@@ -14,6 +14,20 @@ Properties
 
 **batchSize:** Batch size. Defaults to 1. (Macro enabled)
 
+**Write JSON As Array:** Whether to write the JSON as an array. Defaults to false. (Macro enabled)
+
+When set to true, the payload will be written as an array of JSON objects.
+Example - If batch size is 2, then the payload will be `[{"key":"val"}, {"key":"val"}]`
+
+When false, the payload will be JSON objects separated by a delimiter.
+Example - If batch size is 2, delimiter is "\n" , then the payload will be `{"key":"val"}\n{"key":"val"}`
+
+**Json Batch Key** Optional key to be used for wrapping json array as object
+Leave empty for no wrapping of the array. Ignored if Write JSON As Array is set to false. (Macro Enabled)
+
+Example - If batch size is 2 and json batch key is "data", then the payload will be
+`{"data": [{"key":"val"}, {"key":"val"}]}` instead of `[{"key":"val"}, {"key":"val"}]`
+
 **messageFormat:** Format to send messsage in. Options are JSON, Form, Custom. Defaults to JSON. (Macro enabled)
 
 **body:** Optional custom message. This is required if the message format is set to 'Custom'.

--- a/src/main/java/io/cdap/plugin/http/common/http/MessageFormatType.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/MessageFormatType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.http.common.http;
+
+import io.cdap.plugin.http.common.EnumWithValue;
+
+/**
+ * An enum which represent a type of message format of an HTTP request body.
+ */
+public enum MessageFormatType implements EnumWithValue {
+
+  JSON,
+  FORM,
+  CUSTOM;
+
+  @Override
+  public String getValue() {
+    return name();
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPOutputFormat.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPOutputFormat.java
@@ -18,6 +18,7 @@ package io.cdap.plugin.http.sink.batch;
 
 import com.google.gson.Gson;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
@@ -25,18 +26,23 @@ import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
+import java.io.IOException;
+
 /**
  * OutputFormat for HTTP writing
  */
 public class HTTPOutputFormat extends OutputFormat<StructuredRecord, StructuredRecord> {
   private static final Gson GSON = new Gson();
   static final String CONFIG_KEY = "http.sink.config";
+  static final String INPUT_SCHEMA_KEY = "http.sink.input.schema";
 
   @Override
-  public RecordWriter<StructuredRecord, StructuredRecord> getRecordWriter(TaskAttemptContext context) {
+  public RecordWriter<StructuredRecord, StructuredRecord> getRecordWriter(TaskAttemptContext context)
+          throws IOException {
     Configuration hConf = context.getConfiguration();
     HTTPSinkConfig config = GSON.fromJson(hConf.get(CONFIG_KEY), HTTPSinkConfig.class);
-    return new HTTPRecordWriter(config);
+    Schema inputSchema = Schema.parseJson(hConf.get(INPUT_SCHEMA_KEY));
+    return new HTTPRecordWriter(config, inputSchema);
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSink.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSink.java
@@ -16,6 +16,7 @@
 
 package io.cdap.plugin.http.sink.batch;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;
@@ -78,7 +79,7 @@ public class HTTPSink extends BatchSink<StructuredRecord, StructuredRecord, Stru
     lineageRecorder.recordWrite("Write", String.format("Wrote to HTTP '%s'", config.getUrl()), fields);
 
     context.addOutput(Output.of(config.getReferenceNameOrNormalizedFQN(),
-                                new HTTPSink.HTTPOutputFormatProvider(config)));
+                                new HTTPSink.HTTPOutputFormatProvider(config, inputSchema)));
   }
 
   /**
@@ -87,9 +88,11 @@ public class HTTPSink extends BatchSink<StructuredRecord, StructuredRecord, Stru
   private static class HTTPOutputFormatProvider implements OutputFormatProvider {
     private static final Gson GSON = new Gson();
     private final HTTPSinkConfig config;
+    private final Schema inputSchema;
 
-    HTTPOutputFormatProvider(HTTPSinkConfig config) {
+    HTTPOutputFormatProvider(HTTPSinkConfig config, Schema inputSchema) {
       this.config = config;
+      this.inputSchema = inputSchema;
     }
 
     @Override
@@ -99,7 +102,8 @@ public class HTTPSink extends BatchSink<StructuredRecord, StructuredRecord, Stru
 
     @Override
     public Map<String, String> getOutputFormatConfiguration() {
-      return Collections.singletonMap("http.sink.config", GSON.toJson(config));
+      return ImmutableMap.of("http.sink.config", GSON.toJson(config),
+                             "http.sink.input.schema", inputSchema == null ? "" : inputSchema.toString());
     }
   }
 

--- a/src/main/java/io/cdap/plugin/http/sink/batch/MessageBuffer.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/MessageBuffer.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.sink.batch;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.format.StructuredRecordStringConverter;
+import io.cdap.plugin.http.common.http.MessageFormatType;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * MessageBuffer is used to store the structured records in a buffer till the batch size is reached.
+ * Once the batch size is reached, the records are converted to the appropriate format and appended to the message.
+ * The message is then returned to the HTTPRecordWriter.
+ */
+public class MessageBuffer {
+  private static final String REGEX_HASHED_VAR = "#s*(\\w+)";
+  private final List<StructuredRecord> buffer;
+  private final String jsonBatchKey;
+  private final Boolean shouldWriteJsonAsArray;
+  private final String delimiterForMessages;
+  private final String charset;
+  private final String customMessageBody;
+  private final Function<List<StructuredRecord>, String> messageFormatter;
+  private final String contentType;
+  private final Schema wrappedMessageSchema;
+
+
+  /**
+   * Constructor for MessageBuffer.
+   *
+   * @param messageFormat          The format of the message. Can be JSON, FORM or CUSTOM.
+   * @param jsonBatchKey           The key to be used for the JSON batch message.
+   * @param shouldWriteJsonAsArray Whether the JSON message should be written as an array.
+   * @param delimiterForMessages   The delimiter to be used for messages.
+   * @param charset                The charset to be used for the message.
+   * @param customMessageBody      The custom message body to be used.
+   */
+  public MessageBuffer(
+          MessageFormatType messageFormat, String jsonBatchKey, boolean shouldWriteJsonAsArray,
+          String delimiterForMessages, String charset, String customMessageBody, Schema inputSchema
+  ) {
+    this.jsonBatchKey = jsonBatchKey;
+    this.delimiterForMessages = delimiterForMessages;
+    this.charset = charset;
+    this.shouldWriteJsonAsArray = shouldWriteJsonAsArray;
+    this.customMessageBody = customMessageBody;
+    this.buffer = new ArrayList<>();
+    switch (messageFormat) {
+      case JSON:
+        messageFormatter = this::formatAsJson;
+        contentType = "application/json";
+        break;
+      case FORM:
+        messageFormatter = this::formatAsForm;
+        contentType = "application/x-www-form-urlencoded";
+        break;
+      case CUSTOM:
+        messageFormatter = this::formatAsCustom;
+        contentType = "text/plain";
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid message format: " + messageFormat);
+    }
+    // A new StructuredRecord is created with the jsonBatchKey as the
+    // field name and the array of records as the value
+    Schema bufferRecordArraySchema = Schema.arrayOf(inputSchema);
+    wrappedMessageSchema = Schema.recordOf("wrapper",
+            Schema.Field.of(jsonBatchKey, bufferRecordArraySchema));
+  }
+
+  /**
+   * Adds a record to the buffer.
+   *
+   * @param record The record to be added.
+   */
+  public void add(StructuredRecord record) {
+    buffer.add(record);
+  }
+
+  /**
+   * Clears the buffer.
+   */
+  public void clear() {
+    buffer.clear();
+  }
+
+  /**
+   * Returns the size of the buffer.
+   */
+  public int size() {
+    return buffer.size();
+  }
+
+  /**
+   * Returns whether the buffer is empty.
+   */
+  public boolean isEmpty() {
+    return buffer.isEmpty();
+  }
+
+  /**
+   * Returns the content type of the message.
+   */
+  public String getContentType() {
+    return contentType;
+  }
+
+  /**
+   * Converts the buffer to the appropriate format and returns the message.
+   */
+  public String getMessage() throws IOException {
+    return messageFormatter.apply(buffer);
+  }
+
+  private String formatAsJson(List<StructuredRecord> buffer) {
+    try {
+      return formatAsJsonInternal(buffer);
+    } catch (IOException e) {
+      throw new IllegalStateException("Error formatting JSON message. Reason: " + e.getMessage(), e);
+    }
+  }
+
+  private String formatAsJsonInternal(List<StructuredRecord> buffer) throws IOException {
+    boolean useJsonBatchKey = !Strings.isNullOrEmpty(jsonBatchKey);
+    if (!shouldWriteJsonAsArray || !useJsonBatchKey) {
+      return getBufferAsJsonList();
+    }
+    StructuredRecord wrappedMessageRecord = StructuredRecord.builder(wrappedMessageSchema)
+            .set(jsonBatchKey, buffer).build();
+    return StructuredRecordStringConverter.toJsonString(wrappedMessageRecord);
+  }
+
+  private String formatAsForm(List<StructuredRecord> buffer) {
+    return buffer.stream()
+            .map(this::createFormMessage)
+            .collect(Collectors.joining(delimiterForMessages));
+  }
+
+  private String formatAsCustom(List<StructuredRecord> buffer) {
+    return buffer.stream()
+            .map(this::createCustomMessage)
+            .collect(Collectors.joining(delimiterForMessages));
+  }
+
+  private String getBufferAsJsonList() throws IOException {
+    StringBuilder sb = new StringBuilder();
+    String delimiter = shouldWriteJsonAsArray ? "," : delimiterForMessages;
+    if (shouldWriteJsonAsArray) {
+      sb.append("[");
+    }
+    for (StructuredRecord record : buffer) {
+      sb.append(StructuredRecordStringConverter.toJsonString(record));
+      sb.append(delimiter);
+    }
+    if (!buffer.isEmpty()) {
+      sb.setLength(sb.length() - delimiter.length());
+    }
+    if (shouldWriteJsonAsArray) {
+      sb.append("]");
+    }
+    return sb.toString();
+  }
+
+  private String createFormMessage(StructuredRecord input) {
+    boolean first = true;
+    String formMessage = null;
+    StringBuilder sb = new StringBuilder("");
+    for (Schema.Field field : input.getSchema().getFields()) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append("&");
+      }
+      sb.append(field.getName());
+      sb.append("=");
+      sb.append((String) input.get(field.getName()));
+    }
+    try {
+      formMessage = URLEncoder.encode(sb.toString(), charset);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException("Error encoding Form message. Reason: " + e.getMessage(), e);
+    }
+    return formMessage;
+  }
+
+  private String createCustomMessage(StructuredRecord input) {
+    String customMessage = customMessageBody;
+    Matcher matcher = Pattern.compile(REGEX_HASHED_VAR).matcher(customMessage);
+    HashMap<String, String> findReplaceMap = new HashMap();
+    while (matcher.find()) {
+      if (input.get(matcher.group(1)) != null) {
+        findReplaceMap.put(matcher.group(1), (String) input.get(matcher.group(1)));
+      } else {
+        throw new IllegalArgumentException(String.format(
+                "Field %s doesnt exist in the input schema.", matcher.group(1)));
+      }
+    }
+    Matcher replaceMatcher = Pattern.compile(REGEX_HASHED_VAR).matcher(customMessage);
+    while (replaceMatcher.find()) {
+      String val = replaceMatcher.group().replace("#", "");
+      customMessage = (customMessage.replace(replaceMatcher.group(), findReplaceMap.get(val)));
+    }
+    return customMessage;
+  }
+
+}

--- a/src/test/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfigTest.java
@@ -49,9 +49,10 @@ public class HTTPSinkConfigTest {
     1,
     1,
     true,
-          "true",
-          "basicAuth"
-  );
+          "false",
+          "none",
+          "results",
+          false);
 
   @Test
   public void testValidConfig() {
@@ -159,6 +160,39 @@ public class HTTPSinkConfigTest {
     config.validateSchema(schema, collector);
     Assert.assertTrue(collector.getValidationFailures().isEmpty());
   }
+
+    @Test(expected = ValidationException.class)
+    public void testHTTPSinkWithNegativeBatchSize() {
+      HTTPSinkConfig config = HTTPSinkConfig.newBuilder(VALID_CONFIG)
+        .setBatchSize(-1)
+        .build();
+
+      MockFailureCollector collector = new MockFailureCollector("httpsinkwithnegativebatchsize");
+      config.validate(collector);
+      collector.getOrThrowException();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void testHTTPSinkWithZeroBatchSize() {
+      HTTPSinkConfig config = HTTPSinkConfig.newBuilder(VALID_CONFIG)
+        .setBatchSize(0)
+        .build();
+
+      MockFailureCollector collector = new MockFailureCollector("httpsinkwithzerobatchsize");
+      config.validate(collector);
+      collector.getOrThrowException();
+    }
+
+    @Test
+    public void testHTTPSinkWithPositiveBatchSize() {
+      HTTPSinkConfig config = HTTPSinkConfig.newBuilder(VALID_CONFIG)
+        .setBatchSize(42)
+        .build();
+
+      MockFailureCollector collector = new MockFailureCollector("httpsinkwithpositivebatchsize");
+      config.validate(collector);
+      Assert.assertTrue(collector.getValidationFailures().isEmpty());
+    }
 
   public static void assertPropertyValidationFailed(MockFailureCollector failureCollector, String paramName) {
     List<ValidationFailure> failureList = failureCollector.getValidationFailures();

--- a/src/test/java/io/cdap/plugin/http/sink/batch/MessageBufferTest.java
+++ b/src/test/java/io/cdap/plugin/http/sink/batch/MessageBufferTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.sink.batch;
+
+import com.google.gson.stream.JsonWriter;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+/**
+ * Tests for {@link MessageBuffer}
+ */
+public class MessageBufferTest {
+  private static final HTTPSinkConfig VALID_CONFIG = new HTTPSinkConfig(
+          "test",
+          "http://localhost",
+          "GET",
+          1,
+          ":",
+          "JSON",
+          "body",
+          "",
+          "UTF8",
+          true,
+          true,
+          1,
+          1,
+          1,
+          true,
+          "false",
+          "none",
+          "results",
+          true);
+  MessageBuffer messageBuffer;
+  Schema dummySchema = Schema.recordOf("dummy",
+          Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+          Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+          Schema.Field.of("country", Schema.of(Schema.Type.STRING)));
+  StructuredRecord[] dummyRecords;
+  String[] dummyRecordsJsonString;
+  StringWriter stringWriter;
+  JsonWriter jsonWriter;
+
+  @Before
+  public void setUp() throws Exception {
+    stringWriter = new StringWriter();
+    jsonWriter = new JsonWriter(stringWriter);
+    dummyRecords = new StructuredRecord[]{
+            StructuredRecord.builder(dummySchema).set("id", 1).set("name", "John").set("country", "USA").build(),
+            StructuredRecord.builder(dummySchema).set("id", 2).set("name", "Jane").set("country", "Canada").build(),
+            StructuredRecord.builder(dummySchema).set("id", 3).set("name", "Jack").set("country", "USA").build(),
+            StructuredRecord.builder(dummySchema).set("id", 4).set("name", "Jill").set("country", "Canada").build(),
+            StructuredRecord.builder(dummySchema).set("id", 5).set("name", "Joe").set("country", "USA").build(),
+    };
+    dummyRecordsJsonString = new String[]{
+            "{\"id\":1,\"name\":\"John\",\"country\":\"USA\"}",
+            "{\"id\":2,\"name\":\"Jane\",\"country\":\"Canada\"}",
+            "{\"id\":3,\"name\":\"Jack\",\"country\":\"USA\"}",
+            "{\"id\":4,\"name\":\"Jill\",\"country\":\"Canada\"}",
+            "{\"id\":5,\"name\":\"Joe\",\"country\":\"USA\"}"
+    };
+  }
+
+  @Test
+  public void testAdding5RecordsWithBatchSize1() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1).build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1.getMessageFormat(), httpSinkConfigWithBatchSize1.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1.getCharset(), httpSinkConfigWithBatchSize1.getBody(), dummySchema
+    );
+    for (StructuredRecord record : dummyRecords) {
+      messageBuffer.add(record);
+    }
+    Assert.assertEquals(dummyRecords.length, messageBuffer.size());
+  }
+
+  @Test
+  public void testAdding5RecordsWithBatchSize3() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize3 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(3).build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize3.getMessageFormat(), httpSinkConfigWithBatchSize3.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize3.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize3.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize3.getCharset(), httpSinkConfigWithBatchSize3.getBody(), dummySchema
+    );
+    for (StructuredRecord record : dummyRecords) {
+      messageBuffer.add(record);
+    }
+    Assert.assertEquals(dummyRecords.length, messageBuffer.size());
+  }
+
+  @Test
+  public void testClear() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1).build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1.getMessageFormat(), httpSinkConfigWithBatchSize1.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1.getCharset(), httpSinkConfigWithBatchSize1.getBody(), dummySchema
+    );
+    for (StructuredRecord record : dummyRecords) {
+      messageBuffer.add(record);
+    }
+    Assert.assertEquals(dummyRecords.length, messageBuffer.size());
+    messageBuffer.clear();
+    Assert.assertEquals(0, messageBuffer.size());
+  }
+
+  @Test
+  public void testIsEmpty() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1).build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1.getMessageFormat(), httpSinkConfigWithBatchSize1.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1.getCharset(), httpSinkConfigWithBatchSize1.getBody(), dummySchema
+    );
+    Assert.assertTrue(messageBuffer.isEmpty());
+  }
+
+  @Test
+  public void testIsEmptyAfterClear() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1).build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1.getMessageFormat(), httpSinkConfigWithBatchSize1.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1.getCharset(), httpSinkConfigWithBatchSize1.getBody(), dummySchema
+    );
+    for (StructuredRecord record : dummyRecords) {
+      messageBuffer.add(record);
+    }
+    Assert.assertEquals(dummyRecords.length, messageBuffer.size());
+    messageBuffer.clear();
+    Assert.assertTrue(messageBuffer.isEmpty());
+  }
+
+  @Test
+  public void testGetContentTypeWithJsonFormat() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithMessageFormatJson = HTTPSinkConfig.newBuilder(VALID_CONFIG)
+            .setMessageFormat("JSON").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithMessageFormatJson.getMessageFormat(),
+            httpSinkConfigWithMessageFormatJson.getJsonBatchKey(),
+            httpSinkConfigWithMessageFormatJson.shouldWriteJsonAsArray(),
+            httpSinkConfigWithMessageFormatJson.getDelimiterForMessages(),
+            httpSinkConfigWithMessageFormatJson.getCharset(), httpSinkConfigWithMessageFormatJson.getBody(), dummySchema
+    );
+    Assert.assertEquals("application/json", messageBuffer.getContentType());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize1() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1 = HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1)
+            .setMessageFormat("JSON").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1.getMessageFormat(), httpSinkConfigWithBatchSize1.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1.getCharset(), httpSinkConfigWithBatchSize1.getBody(), dummySchema
+    );
+
+    messageBuffer.add(dummyRecords[0]);
+
+    Assert.assertEquals(dummyRecordsJsonString[0], messageBuffer.getMessage());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(3).setMessageFormat("JSON").setWriteJsonAsArray(true)
+                    .setJsonBatchKey("").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.getMessageFormat(),
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.getCharset(),
+            httpSinkConfigWithBatchSize3AndJsonArrayTrueAndWrapperKeyEmptyString.getBody(), dummySchema
+    );
+
+    int batchSize = 3;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    Assert.assertEquals("[" + dummyRecordsJsonString[0] + "," + dummyRecordsJsonString[1] + "," +
+            dummyRecordsJsonString[2] + "]", messageBuffer.getMessage());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize2AndJsonArrayTrueAndWrapperKeyData() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(2).setMessageFormat("JSON").setWriteJsonAsArray(true)
+                    .setJsonBatchKey("data").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.getMessageFormat(),
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.getCharset(),
+            httpSinkConfigWithBatchSize2AndJsonArrayTrueAndWrapperKeyData.getBody(), dummySchema
+    );
+
+    int batchSize = 2;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    jsonWriter.beginObject();
+    jsonWriter.name("data");
+    jsonWriter.beginArray();
+    for (int i = 0; i < batchSize; i++) {
+      jsonWriter.jsonValue(dummyRecordsJsonString[i]);
+    }
+    jsonWriter.endArray();
+    jsonWriter.endObject();
+
+    Assert.assertEquals(stringWriter.toString(), messageBuffer.getMessage());
+
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter()
+          throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(4).setMessageFormat("JSON")
+                    .setWriteJsonAsArray(false).setJsonBatchKey("").setDelimiterForMessages("|").build();
+    messageBuffer =
+            new MessageBuffer(
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getMessageFormat(),
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getJsonBatchKey(),
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .shouldWriteJsonAsArray(),
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getDelimiterForMessages(),
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getCharset(),
+                    httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter.getBody(),
+                    dummySchema
+            );
+
+    int batchSize = 4;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    Assert.assertEquals(dummyRecordsJsonString[0] + "|" + dummyRecordsJsonString[1] + "|" +
+            dummyRecordsJsonString[2] + "|" + dummyRecordsJsonString[3], messageBuffer.getMessage());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter()
+          throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(4).setMessageFormat("JSON")
+                    .setWriteJsonAsArray(false).setJsonBatchKey("data").setDelimiterForMessages("|").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.getMessageFormat(),
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.getCharset(),
+            httpSinkConfigWithBatchSize4AndJsonArrayFalseAndWrapperKeyDataAndCustomDelimiter.getBody(), dummySchema
+    );
+
+    int batchSize = 4;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    Assert.assertEquals(dummyRecordsJsonString[0] + "|" + dummyRecordsJsonString[1] + "|" +
+            dummyRecordsJsonString[2] + "|" + dummyRecordsJsonString[3], messageBuffer.getMessage());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(5).setMessageFormat("JSON").setWriteJsonAsArray(true)
+                    .setJsonBatchKey("items").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.getMessageFormat(),
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.getCharset(),
+            httpSinkConfigWithBatchSize5AndJsonArrayTrueAndWrapperKeyItems.getBody(), dummySchema
+    );
+
+    int batchSize = 5;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    jsonWriter.beginObject();
+    jsonWriter.name("items");
+    jsonWriter.beginArray();
+    for (String jsonRecord : dummyRecordsJsonString) {
+      jsonWriter.jsonValue(jsonRecord);
+    }
+    jsonWriter.endArray();
+    jsonWriter.endObject();
+
+    Assert.assertEquals(stringWriter.toString(), messageBuffer.getMessage());
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize1AndJsonArrayTrueAndWrapperKeyData() throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(1).setMessageFormat("JSON").setWriteJsonAsArray(true)
+                    .setJsonBatchKey("data").build();
+    messageBuffer = new MessageBuffer(
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.getMessageFormat(),
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.getJsonBatchKey(),
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.shouldWriteJsonAsArray(),
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.getDelimiterForMessages(),
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.getCharset(),
+            httpSinkConfigWithBatchSize1AndJsonArrayTrueAndWrapperKeyData.getBody(), dummySchema
+    );
+
+    messageBuffer.add(dummyRecords[0]);
+
+    jsonWriter.beginObject();
+    jsonWriter.name("data");
+    jsonWriter.beginArray();
+    jsonWriter.jsonValue(dummyRecordsJsonString[0]);
+    jsonWriter.endArray();
+    jsonWriter.endObject();
+
+    Assert.assertEquals(stringWriter.toString(), messageBuffer.getMessage());
+
+  }
+
+  @Test
+  public void testGetMessageWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter()
+          throws Exception {
+    HTTPSinkConfig httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter =
+            HTTPSinkConfig.newBuilder(VALID_CONFIG).setBatchSize(2).setMessageFormat("JSON")
+                    .setWriteJsonAsArray(false).setJsonBatchKey("").setDelimiterForMessages(",").build();
+    messageBuffer =
+            new MessageBuffer(
+                httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                        .getMessageFormat(),
+                    httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getJsonBatchKey(),
+                    httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .shouldWriteJsonAsArray(),
+                    httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getDelimiterForMessages(),
+                    httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getCharset(),
+                    httpSinkConfigWithBatchSize2AndJsonArrayFalseAndWrapperKeyEmptyStringAndCustomDelimiter
+                            .getBody(), dummySchema
+            );
+
+    int batchSize = 2;
+    for (int i = 0; i < batchSize; i++) {
+      messageBuffer.add(dummyRecords[i]);
+    }
+
+    Assert.assertEquals(dummyRecordsJsonString[0] + "," + dummyRecordsJsonString[1],
+            messageBuffer.getMessage());
+  }
+}

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -39,6 +39,30 @@
           }
         },
         {
+          "name": "writeJsonAsArray",
+          "label": "Write JSON As Array",
+          "widget-type": "toggle",
+          "widget-attributes": {
+            "on": {
+              "value": "true",
+              "label": "True"
+            },
+            "off": {
+              "value": "false",
+              "label": "False"
+            },
+            "default": "false"
+          }
+        },
+        {
+            "widget-type": "textbox",
+            "label": "Json Batch Key",
+            "name": "jsonBatchKey",
+            "widget-attributes": {
+              "default": ""
+            }
+        },
+        {
           "widget-type": "select",
           "label": "Message Format",
           "name": "messageFormat",
@@ -293,6 +317,30 @@
   ],
   "outputs": [],
   "filters": [
+    {
+      "name": "Should Write Json As Array",
+        "condition": {
+            "expression": "messageFormat == 'JSON'"
+        },
+      "show": [
+        {
+          "type": "property",
+          "name": "writeJsonAsArray"
+        }
+      ]
+    },
+    {
+        "name": "JsonBatchKey",
+        "condition": {
+          "expression": "messageFormat == 'JSON'"
+        },
+        "show": [
+          {
+            "type": "property",
+            "name": "jsonBatchKey"
+          }
+        ]
+    },
     {
       "name": "Authenticate with Basic Auth",
       "condition": {


### PR DESCRIPTION
## Updating support for JSON batch message 
### Bug 
Previously when selecting batch size `> 1` JSON messages were joined with `\n`
The end service failed to parse JSON messages with `\n`
### Update
JSON messages should be joined as defined in the JSON format `[ {} , {} ]`

For services that accept object instead of an array as input we let user define a `Json Batch Key` (Optional) that is used to wrap the JSON array

## UI Field
<img width="651" alt="image" src="https://github.com/data-integrations/http/assets/122770897/fccf2a3b-1907-4247-b5f0-3b43cd48a9e6">

## UI Field (Filter)
The UI field is only visible when `messageFormat == JSON` and `batchSize > 1`

## UI Field (Validation)
The value for key has allowed characters (a-z, A-Z, 0-9, _, -, .)

## Batch Size (Validation)
Previously there was no validation on the batch size , causing illegal user inputs to be valid.
New validation let's user only enter a valid +ve number greater than 0 

## Unit Test
6 Unit test cases were
### Test for batch size
- testHTTPSinkWith`NegativeBatchSize`
- testHTTPSinkWith`ZeroBatchSize`
- testHTTPSinkWith`PositiveBatchSize`

### Test for valid batch key value
- testHTTPSinkWithBatchKeyContaining`Space`
- testHTTPSinkWithBatchKeyContaining`DoubleQuotes`
- testHTTPSinkWithBatchKeyContaining`AlphaNumeric`

<img width="482" alt="image" src="https://github.com/data-integrations/http/assets/122770897/c92bd6fb-e2da-4fca-ada3-30e8c135e7f4">

## Docs 
Updated docs for the new field added to UI

## Code change
- Messages are stored in a buffer array , when the array length is equal to batch-size we call the function `flushMessageBuffer` that moves all messages from the array to a single string that will be set as the message body.
 The function is responsible for joining all the message as per format selected by user
- Long if - else if - else condition are changes to switch case
- Update createFormMessage to url encode only the key and value
- Added fieldToString to keep all messages (form/json/custom) have same result for each field

## Jira Link
 - [Jira Link](https://cdap.atlassian.net/browse/PLUGIN-1676)


 