### PR TITLE
Plugin [1699,1700] - Http_enhancements

### DIFF
--- a/docs/HTTP-batchsink.md
+++ b/docs/HTTP-batchsink.md
@@ -85,6 +85,14 @@ Skip on error - Ignores erroneous records.
 
 **readTimeout:** The time in milliseconds to wait for a read. Set to 0 for infinite. Defaults to 60000 (1 minute). (Macro enabled)
 
+### HTTP Proxy
+
+**Proxy URL:** Proxy URL. Must contain a protocol, address and port.
+
+**Username:** Proxy username.
+
+**Password:** Proxy password.
+
 Example
 -------
 This example performs HTTP POST request to http://example.com/data.

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <jackson.version>2.9.9</jackson.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.7.1</jython.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.24.0</mockito.version>
     <spark2.version>2.1.3</spark2.version>
     <unxml.version>0.9</unxml.version>
     <wiremock.version>1.49</wiremock.version>
@@ -428,8 +428,20 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
@@ -167,10 +167,10 @@ public class HttpClient implements Closeable {
   /**
    * This class allows us to send body not only in POST/PUT but also in other requests.
    */
-  private static class HttpRequest extends HttpEntityEnclosingRequestBase {
+  public static class HttpRequest extends HttpEntityEnclosingRequestBase {
     private final String methodName;
 
-    HttpRequest(URI uri, String methodName) {
+    public HttpRequest(URI uri, String methodName) {
       super();
       this.setURI(uri);
       this.methodName = methodName;

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -105,7 +105,7 @@ public class OAuthUtil {
    * @return
    * @throws IOException
    */
-  private static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
+  public static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
                                                          BaseHttpConfig config) throws IOException {
     URI uri;
     try {

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -67,9 +67,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   public static final String PROPERTY_RESULT_PATH = "resultPath";
   public static final String PROPERTY_FIELDS_MAPPING = "fieldsMapping";
   public static final String PROPERTY_CSV_SKIP_FIRST_ROW = "csvSkipFirstRow";
-  public static final String PROPERTY_PROXY_URL = "proxyUrl";
-  public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
-  public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
   public static final String PROPERTY_HTTP_ERROR_HANDLING = "httpErrorsHandling";
   public static final String PROPERTY_ERROR_HANDLING = "errorHandling";
   public static final String PROPERTY_RETRY_POLICY = "retryPolicy";
@@ -151,24 +148,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     "This is usually set if the first row is a header row.")
   @Macro
   protected String csvSkipFirstRow;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_URL)
-  @Description("Proxy URL. Must contain a protocol, address and port.")
-  @Macro
-  protected String proxyUrl;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_USERNAME)
-  @Description("Proxy username.")
-  @Macro
-  protected String proxyUsername;
-
-  @Nullable
-  @Name(PROPERTY_PROXY_PASSWORD)
-  @Description("Proxy password.")
-  @Macro
-  protected String proxyPassword;
 
   @Nullable
   @Name(PROPERTY_HTTP_ERROR_HANDLING)
@@ -376,21 +355,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
 
   public Boolean getCsvSkipFirstRow() {
     return Boolean.parseBoolean(csvSkipFirstRow);
-  }
-
-  @Nullable
-  public String getProxyUrl() {
-    return proxyUrl;
-  }
-
-  @Nullable
-  public String getProxyUsername() {
-    return proxyUsername;
-  }
-
-  @Nullable
-  public String getProxyPassword() {
-    return proxyPassword;
   }
 
   @Nullable

--- a/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
@@ -16,36 +16,212 @@
 
 package io.cdap.plugin.http.source.common;
 
+import com.google.auth.oauth2.AccessToken;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.OAuthUtil;
+import io.cdap.plugin.http.common.pagination.BaseHttpPaginationIterator;
+import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
 import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.StatusLine;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
 
 /**
  * Unit tests for HttpBatchSourceConfig
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PaginationIteratorFactory.class, HttpClientBuilder.class, HttpClients.class, OAuthUtil.class,
+  HttpHost.class, EntityUtils.class, HttpClient.class})
+@PowerMockIgnore("javax.management.*")
 public class HttpBatchSourceConfigTest {
 
-    @Test (expected = IllegalArgumentException.class)
-    public void testMissingKeyValue() {
-        FailureCollector collector = new MockFailureCollector();
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validate(collector);
-    }
+  @Mock
+  private HttpClient httpClient;
 
-    @Test (expected = InvalidConfigPropertyException.class)
-    public void testEmptySchemaKeyValue() {
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validateSchema();
+  @Mock
+  private CloseableHttpResponse response;
+
+  @Mock
+  private StatusLine statusLine;
+
+  @Mock
+  private HttpEntity entity;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMissingKeyValue() {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validate(collector);
+  }
+
+  @Test(expected = InvalidConfigPropertyException.class)
+  public void testEmptySchemaKeyValue() {
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validateSchema();
+  }
+
+  @Test
+  public void testValidateOAuth2() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxy() throws IOException {
+    FailureCollector collector = new MockFailureCollector();
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").setProxyUrl("https://proxy").setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+      .build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(HttpClients.custom()
+      .setDefaultCredentialsProvider(credentialsProvider)
+      .setProxy(proxy)
+      .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collectorMock);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequest() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n" +
+      "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n" +
+      "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    try {
+      config.validate(collector);
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(1, collector.getValidationFailures().size());
     }
+  }
+
+  @Test
+  public void testBasicAuthWithValidResponse() throws IOException {
+    FailureCollector failureCollector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
+        "username").setPassword("password").setRetryPolicy(
+        "exponential").build();
+    Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
+    Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
+    config.validateBasicAuthResponse(failureCollector, httpClient);
+    Assert.assertEquals(0, failureCollector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidConfigNon200() throws IOException {
+    FailureCollector failureCollector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
+        "username").setPassword("password").setRetryPolicy(
+        "exponential").build();
+    Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
+    Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+    Mockito.when(statusLine.getStatusCode()).thenReturn(400);
+    Mockito.when(response.getEntity()).thenReturn(entity);
+    config.validateBasicAuthResponse(failureCollector, httpClient);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Request failed with status code: 400 null", failureCollector
+      .getValidationFailures().get(0).getMessage());
+  }
+
 }

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -359,6 +359,26 @@
           }
         }
       ]
+    },
+    {
+      "label": "HTTP Proxy",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Proxy URL",
+          "name": "proxyUrl"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Username",
+          "name": "proxyUsername"
+        },
+        {
+          "widget-type": "password",
+          "label": "Password",
+          "name": "proxyPassword"
+        }
+      ]
     }
   ],
   "outputs": [],
@@ -398,6 +418,23 @@
         {
           "type": "property",
           "name": "jsonBatchKey"
+        }
+      ]
+    },
+    {
+      "name": "Proxy authentication",
+      "condition": {
+        "property": "proxyUrl",
+        "operator": "exists"
+      },
+      "show": [
+        {
+          "name": "proxyUsername",
+          "type": "property"
+        },
+        {
+          "name": "proxyPassword",
+          "type": "property"
         }
       ]
     },


### PR DESCRIPTION
The HTTP Source Plugin offers different authentication methods but does not report errors for incorrect credentials provided in the authentication for a specific URL.
Fix
Validate the credentials and provide meaningful errors to identify the field causing the failure for the supported Authentications.
Supported Auth: OAuth or basic auth (username and password)
https://cdap.atlassian.net/browse/PLUGIN-1699

Issue: HTTP Proxy Configuration Missing in HTTP Sink Plugin
**Fix **
To address this issue and provide users with HTTP Proxy support in the HTTP Sink plugin, we propose configuring the following fields:
HTTP Proxy :
Proxy URL
Proxy Username
Proxy Password
https://cdap.atlassian.net/browse/PLUGIN-1700