### PR TITLE
Plugin [1699] - Http_Credentials Validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <jackson.version>2.9.9</jackson.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.7.1</jython.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>2.24.0</mockito.version>
     <spark2.version>2.1.3</spark2.version>
     <unxml.version>0.9</unxml.version>
     <wiremock.version>1.49</wiremock.version>
@@ -428,8 +428,20 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -300,7 +300,6 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         // Validate OAuth2 properties
         if (!containsMacro(PROPERTY_OAUTH2_ENABLED) && this.getOauth2Enabled()) {
             String reasonOauth2 = "OAuth2 is enabled";
-            assertIsSet(getAuthUrl(), PROPERTY_AUTH_URL, reasonOauth2);
             assertIsSet(getTokenUrl(), PROPERTY_TOKEN_URL, reasonOauth2);
             assertIsSet(getClientId(), PROPERTY_CLIENT_ID, reasonOauth2);
             assertIsSet(getClientSecret(), PROPERTY_CLIENT_SECRET, reasonOauth2);
@@ -312,9 +311,6 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         switch (authType) {
             case OAUTH2:
                 String reasonOauth2 = "OAuth2 is enabled";
-                if (!containsMacro(PROPERTY_AUTH_URL)) {
-                    assertIsSet(getAuthUrl(), PROPERTY_AUTH_URL, reasonOauth2);
-                }
                 if (!containsMacro(PROPERTY_TOKEN_URL)) {
                     assertIsSet(getTokenUrl(), PROPERTY_TOKEN_URL, reasonOauth2);
                 }

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -105,7 +105,7 @@ public class OAuthUtil {
    * @return
    * @throws IOException
    */
-  private static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
+  public static AccessToken getAccessTokenByRefreshToken(CloseableHttpClient httpclient,
                                                          BaseHttpConfig config) throws IOException {
     URI uri;
     try {

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -15,8 +15,29 @@
  */
 package io.cdap.plugin.http.source.batch;
 
+import com.google.common.base.Strings;
+import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.http.common.http.AuthType;
+import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpStatus;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
 
 /**
  * Provides all the configurations required for configuring the {@link HttpBatchSource} plugin.
@@ -29,6 +50,75 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
   @Override
   public void validate(FailureCollector failureCollector) {
     super.validate(failureCollector);
+    validateCredentials(failureCollector);
+  }
+
+  public void validateCredentials(FailureCollector collector) {
+    try {
+      if (getAuthType() == AuthType.OAUTH2) {
+        validateOAuth2Credentials(collector);
+      } else if (getAuthType() == AuthType.BASIC_AUTH) {
+        validateBasicAuthCredentials(collector);
+      }
+    } catch (IOException e) {
+      String errorMessage = "Unable to authenticate the given info : " + e.getMessage();
+      collector.addFailure(errorMessage, null);
+    }
+  }
+
+  private void validateOAuth2Credentials(FailureCollector collector) throws IOException {
+    if (!containsMacro(PROPERTY_CLIENT_ID) && !containsMacro(PROPERTY_CLIENT_SECRET) &&
+      !containsMacro(PROPERTY_TOKEN_URL) && !containsMacro(PROPERTY_REFRESH_TOKEN) &&
+      !containsMacro(PROPERTY_PROXY_PASSWORD) && !containsMacro(PROPERTY_PROXY_USERNAME) &&
+      !containsMacro(PROPERTY_PROXY_URL)) {
+      HttpClientBuilder httpclientBuilder = HttpClients.custom();
+      if (!Strings.isNullOrEmpty(getProxyUrl())) {
+        HttpHost proxyHost = HttpHost.create(getProxyUrl());
+        if (!Strings.isNullOrEmpty(getProxyUsername()) && !Strings.isNullOrEmpty(getProxyPassword())) {
+          CredentialsProvider credsProvider = new BasicCredentialsProvider();
+          credsProvider.setCredentials(new AuthScope(proxyHost),
+            new UsernamePasswordCredentials(getProxyUsername(), getProxyPassword()));
+          httpclientBuilder.setDefaultCredentialsProvider(credsProvider);
+        }
+        httpclientBuilder.setProxy(proxyHost);
+      }
+
+      try (CloseableHttpClient closeableHttpClient = httpclientBuilder.build()) {
+        OAuthUtil.getAccessTokenByRefreshToken(closeableHttpClient, this);
+      } catch (JsonSyntaxException | HttpHostConnectException e) {
+        String errorMessage = "Error occurred during credential validation : " + e.getMessage();
+        collector.addFailure(errorMessage, null);
+      }
+    }
+  }
+
+  public void validateBasicAuthCredentials(FailureCollector collector) throws IOException {
+    try {
+      if (!containsMacro(PROPERTY_URL) && !containsMacro(PROPERTY_USERNAME) && !containsMacro(PROPERTY_PASSWORD) &&
+        !containsMacro(PROPERTY_PROXY_USERNAME) && !containsMacro(PROPERTY_PROXY_PASSWORD)
+        && !containsMacro(PROPERTY_PROXY_URL)) {
+        HttpClient httpClient = new HttpClient(this);
+        validateBasicAuthResponse(collector, httpClient);
+      }
+    } catch (HttpHostConnectException e) {
+      String errorMessage = "Error occurred during credential validation : " + e.getMessage();
+      collector.addFailure(errorMessage, "Please ensure that correct credentials are provided.");
+    }
+  }
+
+  public void validateBasicAuthResponse(FailureCollector collector, HttpClient httpClient) throws IOException {
+    try (CloseableHttpResponse response = httpClient.executeHTTP(getUrl())) {
+      int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+          String errorResponse = EntityUtils.toString(entity, "UTF-8");
+          String errorMessage = String.format("Credential validation request failed with Http Status code: '%d', " +
+            "Response: '%s'", statusCode, errorResponse);
+          collector.addFailure(errorMessage, "Please ensure that correct credentials are provided.");
+        }
+      }
+    }
   }
 
   private HttpBatchSourceConfig(HttpBatchSourceConfigBuilder builder) {
@@ -46,6 +136,16 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     this.paginationType = builder.paginationType;
     this.verifyHttps = builder.verifyHttps;
     this.authType = builder.authType;
+    this.authUrl = builder.authUrl;
+    this.clientId = builder.clientId;
+    this.clientSecret = builder.clientSecret;
+    this.username = builder.username;
+    this.password = builder.password;
+    this.tokenUrl = builder.tokenUrl;
+    this.refreshToken = builder.refreshToken;
+    this.proxyUrl = builder.proxyUrl;
+    this.proxyUsername = builder.proxyUsername;
+    this.proxyPassword = builder.proxyPassword;
   }
 
   public static HttpBatchSourceConfigBuilder builder() {
@@ -71,9 +171,75 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     private String paginationType;
     private String verifyHttps;
     private String authType;
+    private String authUrl;
+    private String tokenUrl;
+    private String clientId;
+    private String clientSecret;
+    private String scopes;
+    private String refreshToken;
+    private String proxyUrl;
+    private String proxyUsername;
+    private String proxyPassword;
+    private String username;
+    private String password;
+
 
     public HttpBatchSourceConfigBuilder setReferenceName (String referenceName) {
       this.referenceName = referenceName;
+      return this;
+    }
+    public HttpBatchSourceConfigBuilder setAuthUrl(String authUrl) {
+      this.authUrl = authUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setTokenUrl(String tokenUrl) {
+      this.tokenUrl = tokenUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setClientId(String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setClientSecret(String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setScopes(String scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setRefreshToken(String refreshToken) {
+      this.refreshToken = refreshToken;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyUrl(String proxyUrl) {
+      this.proxyUrl = proxyUrl;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyUsername(String proxyUsername) {
+      this.proxyUsername = proxyUsername;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setProxyPassword(String proxyPassword) {
+      this.proxyPassword = proxyPassword;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setUsername(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setPassword(String password) {
+      this.password = password;
       return this;
     }
 
@@ -101,7 +267,7 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
       this.oauth2Enabled = oauth2Enabled;
       return this;
     }
-    
+
     public HttpBatchSourceConfigBuilder setErrorHandling(String errorHandling) {
       this.errorHandling = errorHandling;
       return this;

--- a/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
@@ -16,36 +16,213 @@
 
 package io.cdap.plugin.http.source.common;
 
+import com.google.auth.oauth2.AccessToken;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
+import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.OAuthUtil;
+import io.cdap.plugin.http.common.pagination.BaseHttpPaginationIterator;
+import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
 import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.StatusLine;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
 
 /**
  * Unit tests for HttpBatchSourceConfig
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PaginationIteratorFactory.class, HttpClientBuilder.class, HttpClients.class, OAuthUtil.class,
+  HttpHost.class, EntityUtils.class, HttpClient.class})
+@PowerMockIgnore("javax.management.*")
 public class HttpBatchSourceConfigTest {
 
-    @Test (expected = IllegalArgumentException.class)
-    public void testMissingKeyValue() {
-        FailureCollector collector = new MockFailureCollector();
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validate(collector);
-    }
+  @Mock
+  private HttpClient httpClient;
 
-    @Test (expected = InvalidConfigPropertyException.class)
-    public void testEmptySchemaKeyValue() {
-        HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-                .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
-                .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-                .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-                .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
-        config.validateSchema();
+  @Mock
+  private CloseableHttpResponse response;
+
+  @Mock
+  private StatusLine statusLine;
+
+  @Mock
+  private HttpEntity entity;
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMissingKeyValue() {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validate(collector);
+  }
+
+  @Test(expected = InvalidConfigPropertyException.class)
+  public void testEmptySchemaKeyValue() {
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+    config.validateSchema();
+  }
+
+  @Test
+  public void testValidateOAuth2() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxy() throws IOException {
+    FailureCollector collector = new MockFailureCollector();
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").setProxyUrl("https://proxy").setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+      .build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(HttpClients.custom()
+      .setDefaultCredentialsProvider(credentialsProvider)
+      .setProxy(proxy)
+      .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any())).thenReturn(accessToken);
+    config.validate(collectorMock);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequest() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
+      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+        "exponential").build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n" +
+      "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n" +
+      "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    try {
+      config.validate(collector);
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(1, collector.getValidationFailures().size());
     }
+  }
+
+  @Test
+  public void testBasicAuthWithValidResponse() throws IOException {
+    FailureCollector failureCollector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
+        "username").setPassword("password").setRetryPolicy(
+        "exponential").build();
+    Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
+    Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+    Mockito.when(statusLine.getStatusCode()).thenReturn(200);
+    config.validateBasicAuthResponse(failureCollector, httpClient);
+    Assert.assertEquals(0, failureCollector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidConfigWithInvalidResponse() throws IOException {
+    FailureCollector failureCollector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
+      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
+      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
+        "username").setPassword("password").setRetryPolicy(
+        "exponential").build();
+    Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
+    Mockito.when(response.getStatusLine()).thenReturn(statusLine);
+    Mockito.when(statusLine.getStatusCode()).thenReturn(400);
+    Mockito.when(response.getEntity()).thenReturn(entity);
+    config.validateBasicAuthResponse(failureCollector, httpClient);
+    Assert.assertEquals(1, failureCollector.getValidationFailures().size());
+    Assert.assertEquals("Credential validation request failed with Http Status code: '400', Response: 'null'",
+      failureCollector
+      .getValidationFailures().get(0).getMessage());
+  }
+
 }


### PR DESCRIPTION
The HTTP Source Plugin offers different authentication methods but does not report errors for incorrect credentials provided in the authentication for a specific URL.
Fix
Validate the credentials and provide meaningful errors to identify the field causing the failure for the supported Authentications.
Supported Auth: OAuth or basic auth (username and password)
https://cdap.atlassian.net/browse/PLUGIN-1699