### PR TITLE
Bump Plugin version to 1.5.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
### Bump Develop Branch to Version 1.5.0-SNAPSHOT

This PR is a simple version bump in the develop branch from 1.4.0 to 1.5.0-SNAPSHOT. Since Plugin version 1.4.0 has already been released, we are updating the develop branch to reflect the upcoming version.