### PR TITLE
[PLUGIN-1737] Added Schema Detection for CSV/TSV format

### DIFF
--- a/docs/HTTP-batchsource.md
+++ b/docs/HTTP-batchsource.md
@@ -36,6 +36,10 @@ listed in schema.
 Text - transforms a single line of text into a single record with a string field `body` containing the result.  
 BLOB - transforms the entire response into a single record with a byte array field `body` containing the result.
 
+**Get Schema:** Auto-detects schema from file. Supported formats are: csv, tsv.
+
+**Sample Size:** The maximum number of rows in a file that will get investigated for automatic data type detection. Default is 100.
+
 **JSON/XML Result Path:** Path to the results. When the format is XML, this is an XPath. When the format is JSON, this is a JSON path.
 
 JSON path example:
@@ -201,7 +205,12 @@ Note, that field `key` was mapped without being included into the mapping. Mappi
 can be omitted as long as the field is present in schema.
   
 
-**CSV Skip First Row:** Whether to skip the first row of the HTTP response. This is usually set if the first row is a header row.
+**CSV/TSV Skip First Row:** Whether to skip the first row of the HTTP response. This is usually set if the first row is a header row.
+
+**Enable Quoted Values** Whether to treat content between quotes as a value. This value will only be used if the format
+is 'csv', 'tsv'. For example, if this is set to true, a line that looks like `1, "a, b, c"` will output two fields.
+The first field will have `1` as its value and the second will have `a, b, c` as its value. The quote characters will be trimmed.
+The newline delimiter cannot be within quotes.
 
 ### Authentication
 * **OAuth2**

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <hadoop.version>2.3.0</hadoop.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>
     <hydrator.version>2.10.0-SNAPSHOT</hydrator.version>
+    <cdap.plugin.version>2.12.0</cdap.plugin.version>
     <jackson.version>2.9.9</jackson.version>
     <junit.version>4.11</junit.version>
     <jython.version>2.7.1</jython.version>
@@ -125,6 +126,11 @@
       <groupId>io.cdap.plugin</groupId>
       <artifactId>hydrator-common</artifactId>
       <version>${hydrator.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.plugin</groupId>
+      <artifactId>format-delimited</artifactId>
+      <version>${cdap.plugin.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -17,6 +17,7 @@ package io.cdap.plugin.http.source.batch;
 
 import com.google.common.base.Strings;
 import com.google.gson.JsonSyntaxException;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.HttpClient;
@@ -50,6 +51,10 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
   @Override
   public void validate(FailureCollector failureCollector) {
     super.validate(failureCollector);
+    if (!containsMacro(PROPERTY_SAMPLE_SIZE) && getSampleSize() < 1) {
+      failureCollector.addFailure("Sample size must be greater than 0.", null)
+        .withConfigProperty(PROPERTY_SAMPLE_SIZE);
+    }
     validateCredentials(failureCollector);
   }
 
@@ -127,6 +132,9 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     this.httpMethod = builder.httpMethod;
     this.headers = builder.headers;
     this.format = builder.format;
+    this.schema = builder.schema;
+    this.csvSkipFirstRow = builder.csvSkipFirstRow;
+    this.enableQuotesValues = builder.enableQuotesValues;
     this.oauth2Enabled = builder.oauth2Enabled;
     this.errorHandling = builder.errorHandling;
     this.retryPolicy = builder.retryPolicy;
@@ -161,7 +169,10 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     private String url;
     private String httpMethod;
     private String headers;
+    private String schema;
     private String format;
+    private String csvSkipFirstRow;
+    private Boolean enableQuotesValues;
     private String oauth2Enabled;
     private String errorHandling;
     private String retryPolicy;
@@ -258,8 +269,23 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
       return this;
     }
 
+    public HttpBatchSourceConfigBuilder setSchema(String schema) {
+      this.schema = schema;
+      return this;
+    }
+
     public HttpBatchSourceConfigBuilder setFormat(String format) {
       this.format = format;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setCsvSkipFirstRow(String csvSkipFirstRow) {
+      this.csvSkipFirstRow = csvSkipFirstRow;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setEnableQuotesValues(Boolean enableQuotesValues) {
+      this.enableQuotesValues = enableQuotesValues;
       return this;
     }
 

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -24,21 +24,17 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.api.validation.InvalidStageException;
 import io.cdap.plugin.common.ReferenceNames;
-import io.cdap.plugin.common.ReferencePluginConfig;
 import io.cdap.plugin.http.common.BaseHttpConfig;
 import io.cdap.plugin.http.common.EnumWithValue;
 import io.cdap.plugin.http.common.RetryPolicy;
 import io.cdap.plugin.http.common.error.ErrorHandling;
 import io.cdap.plugin.http.common.error.HttpErrorHandlerEntity;
 import io.cdap.plugin.http.common.error.RetryableErrorHandling;
-import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.KeyStoreType;
-import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
 import io.cdap.plugin.http.common.pagination.PaginationType;
 import io.cdap.plugin.http.common.pagination.page.PageFormat;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,9 +60,11 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   public static final String PROPERTY_HEADERS = "headers";
   public static final String PROPERTY_REQUEST_BODY = "requestBody";
   public static final String PROPERTY_FORMAT = "format";
+  public static final String PROPERTY_SAMPLE_SIZE = "sampleSize";
   public static final String PROPERTY_RESULT_PATH = "resultPath";
   public static final String PROPERTY_FIELDS_MAPPING = "fieldsMapping";
   public static final String PROPERTY_CSV_SKIP_FIRST_ROW = "csvSkipFirstRow";
+  public static final String PROPERTY_ENABLE_QUOTES_VALUES = "enableQuotedValues";
   public static final String PROPERTY_HTTP_ERROR_HANDLING = "httpErrorsHandling";
   public static final String PROPERTY_ERROR_HANDLING = "errorHandling";
   public static final String PROPERTY_RETRY_POLICY = "retryPolicy";
@@ -127,6 +125,12 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   @Macro
   protected String format;
 
+  @Macro
+  @Nullable
+  @Name(PROPERTY_SAMPLE_SIZE)
+  @Description("The maximum number of rows that will get investigated for automatic data type detection.")
+  private Long sampleSize;
+
   @Nullable
   @Name(PROPERTY_RESULT_PATH)
   @Description("Path to the results. When the format is XML, this is an XPath. " +
@@ -148,6 +152,13 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     "This is usually set if the first row is a header row.")
   @Macro
   protected String csvSkipFirstRow;
+
+  @Nullable
+  @Name(PROPERTY_ENABLE_QUOTES_VALUES)
+  @Description("Values Whether to treat content between quotes as a value. " +
+          "This value will only be used if the format is ‘csv’, ‘tsv’. Default value is false.")
+  @Macro
+  protected Boolean enableQuotesValues;
 
   @Nullable
   @Name(PROPERTY_HTTP_ERROR_HANDLING)
@@ -343,6 +354,10 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     return getEnumValueByString(PageFormat.class, format, PROPERTY_FORMAT);
   }
 
+  public Long getSampleSize() {
+    return sampleSize == null ? 100L : sampleSize;
+  }
+
   @Nullable
   public String getResultPath() {
     return resultPath;
@@ -355,6 +370,10 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
 
   public Boolean getCsvSkipFirstRow() {
     return Boolean.parseBoolean(csvSkipFirstRow);
+  }
+
+  public boolean getEnableQuotesValues() {
+    return enableQuotesValues != null && enableQuotesValues;
   }
 
   @Nullable
@@ -510,7 +529,8 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
 
   @Nullable
   public Map<String, String> getHeadersMap() {
-    return getMapFromKeyValueString(headers);
+    Map<String, String> headerMap = getMapFromKeyValueString(headers);
+    return headerMap.isEmpty() ? null : Collections.unmodifiableMap(headerMap);
   }
 
   public List<HttpErrorHandlerEntity> getHttpErrorHandlingEntries() {
@@ -676,18 +696,49 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     }
   }
 
+  public boolean canDetectSchema() {
+    return !(containsMacro(PROPERTY_SCHEMA) || containsMacro(PROPERTY_FORMAT) || containsMacro(PROPERTY_URL) ||
+            containsMacro(PROPERTY_PROXY_URL) || containsMacro(PROPERTY_PROXY_USERNAME) ||
+            containsMacro(PROPERTY_PROXY_PASSWORD) || containsMacro(PROPERTY_CSV_SKIP_FIRST_ROW) ||
+            containsMacro(PROPERTY_ENABLE_QUOTES_VALUES) || containsMacro(PROPERTY_USERNAME) ||
+            containsMacro(PROPERTY_PASSWORD) || containsMacro(PROPERTY_AUTH_URL) || containsMacro(PROPERTY_TOKEN_URL) ||
+            containsMacro(PROPERTY_CLIENT_ID) || containsMacro(PROPERTY_CLIENT_SECRET) ||
+            containsMacro(PROPERTY_SCOPES) || containsMacro(PROPERTY_REFRESH_TOKEN) ||
+            containsMacro(PROPERTY_NAME_SERVICE_ACCOUNT_FILE_PATH) ||
+            containsMacro(PROPERTY_VERIFY_HTTPS) || containsMacro(PROPERTY_KEYSTORE_FILE) ||
+            containsMacro(PROPERTY_KEYSTORE_TYPE) || containsMacro(PROPERTY_KEYSTORE_PASSWORD) ||
+            containsMacro(PROPERTY_KEYSTORE_KEY_ALGORITHM) || containsMacro(PROPERTY_TRUSTSTORE_FILE) ||
+            containsMacro(PROPERTY_TRUSTSTORE_TYPE) || containsMacro(PROPERTY_TRUSTSTORE_PASSWORD) ||
+            containsMacro(PROPERTY_TRUSTSTORE_KEY_ALGORITHM) || containsMacro(PROPERTY_TRANSPORT_PROTOCOLS) ||
+            containsMacro(PROPERTY_CIPHER_SUITES) || containsMacro(PROPERTY_HEADERS) ||
+            containsMacro(PROPERTY_HTTP_METHOD) || containsMacro(PROPERTY_SAMPLE_SIZE));
+  }
+
+  public void setConfigSchema(Schema schema) {
+    this.schema = schema == null ? null : schema.toString();
+  }
+
   public void validateSchema() {
     Schema schema = getSchema();
     if (!containsMacro(PROPERTY_SCHEMA) && schema == null) {
-      throw new InvalidConfigPropertyException(
-              String.format("Output schema cannot be empty"), PROPERTY_SCHEMA);
+      // If format is not macro must be csv or tsv else schema is required
+      if (!containsMacro(PROPERTY_FORMAT)) {
+        switch (getFormat()) {
+          case CSV:
+          case TSV:
+            break;
+          default:
+            throw new InvalidConfigPropertyException(
+                    String.format("Output schema cannot be empty"), PROPERTY_SCHEMA);
+        }
+      }
     }
     if (!containsMacro(PROPERTY_FORMAT)) {
       PageFormat format = getFormat();
 
       if (format.equals(PageFormat.TEXT) || format.equals(PageFormat.BLOB)) {
         Schema.Type expectedFieldType = format.equals(PageFormat.TEXT) ? Schema.Type.STRING : Schema.Type.BYTES;
-        List<Schema.Field> fields = getSchema().getFields();
+        List<Schema.Field> fields = schema.getFields();
         if (fields == null || fields.size() != 1 || fields.get(0).getSchema().getType() != expectedFieldType) {
           throw new InvalidStageException(String.format("Schema must be a record with a single %s field.",
                                                         expectedFieldType.toString().toLowerCase()));

--- a/src/main/java/io/cdap/plugin/http/source/common/DelimitedSchemaDetector.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/DelimitedSchemaDetector.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.source.common;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.plugin.format.delimited.common.DataTypeDetectorStatusKeeper;
+import io.cdap.plugin.format.delimited.common.DataTypeDetectorUtils;
+import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Class that detects the schema of the delimited file.
+ */
+public class DelimitedSchemaDetector {
+  public static Schema detectSchema(HttpBatchSourceConfig config, String delimiter,
+                                    RawStringPerLine rawStringPerLine, FailureCollector failureCollector) {
+    DataTypeDetectorStatusKeeper dataTypeDetectorStatusKeeper = new DataTypeDetectorStatusKeeper();
+    String line;
+    String[] columnNames = null;
+    String[] rowValue;
+    long sampleSize = config.getSampleSize();
+    try {
+      for (int rowIndex = 0; rowIndex < sampleSize && rawStringPerLine.hasNext(); rowIndex++) {
+        line = rawStringPerLine.next();
+        rowValue = line.split(delimiter, -1);
+        if (rowIndex == 0) {
+          columnNames = DataTypeDetectorUtils.setColumnNames(line, config.getCsvSkipFirstRow(),
+                  config.getEnableQuotesValues(), delimiter);
+          if (config.getCsvSkipFirstRow()) {
+            continue;
+          }
+        }
+        DataTypeDetectorUtils.detectDataTypeOfRowValues(new HashMap<>(), dataTypeDetectorStatusKeeper, columnNames,
+                rowValue);
+      }
+      dataTypeDetectorStatusKeeper.validateDataTypeDetector();
+    } catch (Exception e) {
+      failureCollector.addFailure(String.format("Error while reading the file to infer the schema. Error: %s",
+                      e.getMessage()), null)
+              .withStacktrace(e.getStackTrace());
+      return null;
+    }
+    List<Schema.Field> fields = DataTypeDetectorUtils.detectDataTypeOfEachDatasetColumn(
+            new HashMap<>(), columnNames, dataTypeDetectorStatusKeeper);
+    return Schema.recordOf("text", fields);
+  }
+}

--- a/src/main/java/io/cdap/plugin/http/source/common/RawStringPerLine.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/RawStringPerLine.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.http.source.common;
+
+
+import io.cdap.plugin.http.common.http.HttpResponse;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Class that reads the raw string from the HTTP response and returns it line by line.
+ */
+public class RawStringPerLine implements Closeable, Iterator<String> {
+    protected final HttpResponse httpResponse;
+    private BufferedReader bufferedReader;
+    private boolean isLineRead;
+    private String lastLine;
+
+    public RawStringPerLine(HttpResponse httpResponse) {
+        this.httpResponse = httpResponse;
+    }
+
+    private BufferedReader getBufferedReader() throws IOException {
+        if (bufferedReader == null) {
+            this.bufferedReader = new BufferedReader(new InputStreamReader(httpResponse.getInputStream()));
+        }
+        return bufferedReader;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (bufferedReader != null) {
+            bufferedReader.close();
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        try {
+            if (!isLineRead) {
+                lastLine = this.getBufferedReader().readLine();
+            }
+            isLineRead = true;
+            return lastLine != null;
+        } catch (IOException e) { // we need to catch this, since hasNext() does not have "throws" in parent
+            throw new RuntimeException("Failed to read line from http page buffer", e);
+        }
+    }
+
+    @Override
+    public String next() {
+        if (!hasNext()) { // calling hasNext will also read the line;
+            throw new NoSuchElementException();
+        }
+        isLineRead = false;
+        return lastLine;
+    }
+}

--- a/src/test/java/io/cdap/plugin/http/common/pagination/page/DelimitedPageTest.java
+++ b/src/test/java/io/cdap/plugin/http/common/pagination/page/DelimitedPageTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.common.pagination.page;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Unit Test for class {@link DelimitedPage}
+ */
+public class DelimitedPageTest {
+  HttpBatchSourceConfig config;
+
+  @Test
+  public void testGetStructuredRecordByString() throws IOException {
+    Schema schema = Schema.recordOf("inputSchema",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("address", Schema.of(Schema.Type.STRING)));
+    config = HttpBatchSourceConfig.builder()
+            .setUrl("http://localhost:10000")
+            .setFormat("csv")
+            .setEnableQuotesValues(true)
+            .setSchema(schema.toString())
+            .build();
+    String id = "1";
+    String address = "123 Main St, San Francisco, CA 94105";
+    String line = id + ",\"" + address + "\"";
+    StructuredRecord structuredRecord;
+    try (DelimitedPage delimitedPage = new DelimitedPage(config, null, ",")) {
+      structuredRecord = delimitedPage.getStructedRecordByString(line);
+    }
+    Assert.assertEquals(id, structuredRecord.get("id"));
+    Assert.assertEquals(address, structuredRecord.get("address"));
+  }
+
+  @Test
+  public void testGetStructuredRecordByStringNormal() throws IOException {
+    Schema schema = Schema.recordOf("inputSchema",
+            Schema.Field.of("id", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    config = HttpBatchSourceConfig.builder()
+            .setUrl("http://localhost:10000")
+            .setFormat("csv")
+            .setEnableQuotesValues(true)
+            .setSchema(schema.toString())
+            .build();
+    String id = "1";
+    String name = "John";
+    String line = id + "," + name;
+    StructuredRecord structuredRecord;
+    try (DelimitedPage delimitedPage = new DelimitedPage(config, null, ",")) {
+      structuredRecord = delimitedPage.getStructedRecordByString(line);
+    }
+    Assert.assertEquals(id, structuredRecord.get("id"));
+    Assert.assertEquals(name, structuredRecord.get("name"));
+  }
+}

--- a/src/test/java/io/cdap/plugin/http/source/common/DelimitedSchemaDetectorTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/DelimitedSchemaDetectorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.source.common;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+/**
+ * Unit test for {@link DelimitedSchemaDetector}
+ */
+public class DelimitedSchemaDetectorTest {
+  @Mock
+  RawStringPerLine rawStringPerLineIterator;
+  HttpBatchSourceConfig configSkipHeaderTrue;
+  HttpBatchSourceConfig configSkipHeaderFalse;
+  String csvDelimiter = ",";
+  String tsvDelimiter = "\t";
+
+  Schema expectedSchemaWithoutHeaders;
+  Schema expectedSchemaWithHeaders;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    configSkipHeaderTrue = HttpBatchSourceConfig.builder().setCsvSkipFirstRow("true").build();
+    configSkipHeaderFalse = HttpBatchSourceConfig.builder().setCsvSkipFirstRow("false").build();
+    expectedSchemaWithHeaders = Schema.recordOf("text",
+            Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("age", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("isIndian", Schema.of(Schema.Type.BOOLEAN)),
+            Schema.Field.of("country", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+    );
+    expectedSchemaWithoutHeaders = Schema.recordOf("text",
+            Schema.Field.of("body_0", Schema.of(Schema.Type.STRING)),
+            Schema.Field.of("body_1", Schema.of(Schema.Type.INT)),
+            Schema.Field.of("body_2", Schema.of(Schema.Type.BOOLEAN)),
+            Schema.Field.of("body_3", Schema.nullableOf(Schema.of(Schema.Type.STRING)))
+    );
+  }
+
+  @Test
+  public void testDetectSchemaCsvNoHeader() throws IOException {
+    String[] lines = new String[] {"raj,29,true,india", "rahul,30,false,"};
+    Mockito.when(rawStringPerLineIterator.hasNext()).thenReturn(true, true, false);
+    Mockito.when(rawStringPerLineIterator.next()).thenReturn(lines[0], lines[1]);
+    Schema schema = DelimitedSchemaDetector.detectSchema(
+            configSkipHeaderFalse, csvDelimiter, rawStringPerLineIterator, null);
+    Assert.assertEquals(expectedSchemaWithoutHeaders, schema);
+  }
+
+  @Test
+  public void testDetectSchemaTsvNoHeader() throws IOException {
+    String[] lines = new String[] {"raj\t29\ttrue\tindia", "rahul\t30\tfalse\t"};
+    Mockito.when(rawStringPerLineIterator.hasNext()).thenReturn(true, true, false);
+    Mockito.when(rawStringPerLineIterator.next()).thenReturn(lines[0], lines[1]);
+    Schema schema = DelimitedSchemaDetector.detectSchema(
+            configSkipHeaderFalse, tsvDelimiter, rawStringPerLineIterator, null);
+    Assert.assertEquals(expectedSchemaWithoutHeaders, schema);
+  }
+
+
+  @Test
+  public void testDetectSchemaCsvHeader() throws IOException {
+    String[] lines = new String[] {"name,age,isIndian,country", "raj,29,true,india", "rahul,30,false,"};
+    Mockito.when(rawStringPerLineIterator.hasNext()).thenReturn(true, true, true, false);
+    Mockito.when(rawStringPerLineIterator.next()).thenReturn(lines[0], lines[1], lines[2]);
+    Schema schema = DelimitedSchemaDetector.detectSchema(
+            configSkipHeaderTrue, csvDelimiter, rawStringPerLineIterator, null);
+    Assert.assertEquals(expectedSchemaWithHeaders, schema);
+  }
+
+  @Test
+  public void testDetectSchemaTsvHeader() throws IOException {
+    String[] lines = new String[] {"name\tage\tisIndian\tcountry", "raj\t29\ttrue\tindia", "rahul\t30\tfalse\t"};
+    Mockito.when(rawStringPerLineIterator.hasNext()).thenReturn(true, true, true, false);
+    Mockito.when(rawStringPerLineIterator.next()).thenReturn(lines[0], lines[1], lines[2]);
+    Schema schema = DelimitedSchemaDetector.detectSchema(
+            configSkipHeaderTrue, tsvDelimiter, rawStringPerLineIterator, null);
+    Assert.assertEquals(expectedSchemaWithHeaders, schema);
+  }
+
+}

--- a/src/test/java/io/cdap/plugin/http/source/common/RawStringPerLineTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/RawStringPerLineTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.http.source.common;
+
+import io.cdap.plugin.http.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Unit test for {@link RawStringPerLine}
+ */
+public class RawStringPerLineTest {
+
+  @Mock
+  HttpResponse httpResponse;
+
+  @Before
+  public void setUp() throws IOException {
+    MockitoAnnotations.initMocks(this);
+    String sampleContent = "Line 1\nLine 2\n";
+    InputStream inputStream = new ByteArrayInputStream(sampleContent.getBytes());
+    Mockito.when(httpResponse.getInputStream()).thenReturn(inputStream);
+  }
+
+  @Test
+  public void testRawStringPerLine() {
+    RawStringPerLine rawStringPerLine = new RawStringPerLine(httpResponse);
+
+    Assert.assertTrue(rawStringPerLine.hasNext());
+    Assert.assertEquals("Line 1", rawStringPerLine.next());
+
+    Assert.assertTrue(rawStringPerLine.hasNext());
+    Assert.assertEquals("Line 2", rawStringPerLine.next());
+
+    Assert.assertFalse(rawStringPerLine.hasNext()); // No more lines
+  }
+}

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -69,6 +69,19 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Sample Size",
+          "name": "sampleSize",
+          "widget-attributes": {
+            "default": "100",
+            "minimum": "1"
+          }
+        },
+        {
+          "widget-type": "get-schema",
+          "widget-category": "plugin"
+        },
+        {
           "widget-type": "textbox",
           "label": "JSON/XML Result Path",
           "name": "resultPath"
@@ -83,8 +96,27 @@
         },
         {
           "widget-type": "radio-group",
-          "label": "CSV Skip First Row",
+          "label": "CSV/TSV Skip First Row",
           "name": "csvSkipFirstRow",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "false",
+            "options": [
+              {
+                "id": "true",
+                "label": "true"
+              },
+              {
+                "id": "false",
+                "label": "false"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "radio-group",
+          "label": "Enable Quoted Values",
+          "name": "enableQuotedValues",
           "widget-attributes": {
             "layout": "inline",
             "default": "false",
@@ -559,6 +591,18 @@
   ],
   "filters": [
     {
+      "name": "GetSchema CSV TSV",
+      "condition": {
+        "expression": "format == 'csv' || format == 'tsv'"
+      },
+      "show": [
+        {
+          "widget-type": "getSchema",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "Proxy authentication",
       "condition": {
         "property": "proxyUrl",
@@ -768,15 +812,37 @@
       ]
     },
     {
+      "name": "Sample Size For CSV TSV",
+      "condition": {
+        "expression": "format == 'csv' || format == 'tsv'"
+      },
+      "show": [
+        {
+          "name": "sampleSize",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "CSV Formatting",
       "condition": {
-        "property": "format",
-        "operator": "equal to",
-        "value": "csv"
+        "expression": "format == 'csv' || format == 'tsv'"
       },
       "show": [
         {
           "name": "csvSkipFirstRow",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Quoted Values",
+      "condition": {
+        "expression": "format == 'csv' || format == 'tsv'"
+      },
+      "show": [
+        {
+          "name": "enableQuotedValues",
           "type": "property"
         }
       ]


### PR DESCRIPTION
##  Added Schema Detection for CSV/TSV format 

Jira : [Plugin-1737](https://cdap.atlassian.net/browse/PLUGIN-1737)

## Description
User will be able to get Schema for delimited files (CSV/TSV)

## UI Fields changes
- Add Schema Button appears when format is csv/tsv
- Sample Size filed appears when format is csv/tsv
- `CSV Skip First Row` is renamed to `CSV/TSV Skip First Row`
- Added new UI field `Enable Quoted Values`

![image](https://github.com/data-integrations/http/assets/122770897/6e79177c-87ea-4bda-98f9-d61d3898e966)


## Docs
 - Docs for new fileds added.
 - CSV Skip First Row renamed.
---

**Get Schema:** Auto-detects schema from file. Supported formats are: csv, tsv.
**Sample Size:** The maximum number of rows in a file that will get investigated for automatic data type detection. 
Default is 100.
**CSV/TSV Skip First Row:** Whether to skip the first row of the HTTP response. This is usually set if the first row is a header row.

---
## Unit Tests

- Unit Test for `DelimitedSchemaDetector`

![image](https://github.com/data-integrations/http/assets/122770897/00b67d2b-712b-4fab-b9e7-ed8b0c8e7950)

- Unit Test for `DelimitedPage`

![image](https://github.com/data-integrations/http/assets/122770897/fd112378-cc92-4673-b46f-6d1cff5b8e09)

- Unit Test for `RawStringPerLine`

![image](https://github.com/data-integrations/http/assets/122770897/e62a1f7a-56e7-4bb4-8dde-5164716bcc12)




