### PR TITLE
Bumped 1.4.0 to 1.4.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1-SNAPSHOT</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
Version `1.4.0` is released !
This PR bumps to next minor release version `1.4.1-SNAPSHOT`
