### PR TITLE
[cherry-pick][PLUGIN-1740] Added Wait Time Between Request Field in HTTP Sink

### DIFF
--- a/docs/HTTP-batchsink.md
+++ b/docs/HTTP-batchsink.md
@@ -85,6 +85,8 @@ Skip on error - Ignores erroneous records.
 
 **readTimeout:** The time in milliseconds to wait for a read. Set to 0 for infinite. Defaults to 60000 (1 minute). (Macro enabled)
 
+**Wait Time Between Request:** Time in milliseconds to wait between HTTP requests. Defaults to 0. (Macro enabled)
+
 ### HTTP Proxy
 
 **Proxy URL:** Proxy URL. Must contain a protocol, address and port.

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -69,6 +69,14 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public static final String PROPERTY_SERVICE_ACCOUNT_SCOPE = "serviceAccountScope";
 
+    public static final String PROPERTY_WAIT_TIME_BETWEEN_PAGES = "waitTimeBetweenPages";
+
+    @Name(PROPERTY_WAIT_TIME_BETWEEN_PAGES)
+    @Nullable
+    @Description("Time in milliseconds to wait between HTTP requests. Default is 0.")
+    @Macro
+    protected Long waitTimeBetweenPages;
+
     @Name(PROPERTY_AUTH_TYPE)
     @Description("Type of authentication used to submit request. \n" +
             "OAuth2, Service account, Basic Authentication types are available.")
@@ -175,6 +183,10 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
             "for more information.")
     @Macro
     protected String serviceAccountScope;
+
+    public long getWaitTimeBetweenPages() {
+        return waitTimeBetweenPages == null ? 0L : Math.max(0, waitTimeBetweenPages);
+    }
 
     public BaseHttpConfig(String referenceName) {
         super(referenceName);

--- a/src/main/java/io/cdap/plugin/http/common/pagination/BaseHttpPaginationIterator.java
+++ b/src/main/java/io/cdap/plugin/http/common/pagination/BaseHttpPaginationIterator.java
@@ -101,7 +101,7 @@ public abstract class BaseHttpPaginationIterator implements Iterator<BasePage>, 
     }
 
     // response being null, means it's the first page we are loading
-    Long delay = (response == null || config.getWaitTimeBetweenPages() == null) ? 0L : config.getWaitTimeBetweenPages();
+    long delay = response == null ? 0L : config.getWaitTimeBetweenPages();
     LOG.debug("Fetching '{}'", nextPageUrl);
 
     try {

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
@@ -343,7 +343,7 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
       Awaitility
         .await().with()
         .pollInterval(pollInterval)
-        .pollDelay(config.getReadTimeout() == null ? 0L : config.getReadTimeout(), TimeUnit.MILLISECONDS)
+        .pollDelay(config.getWaitTimeBetweenPages(), TimeUnit.MILLISECONDS)
         .timeout(config.getMaxRetryDuration(), TimeUnit.SECONDS)
         .until(this::executeHTTPServiceAndCheckStatusCode);
     } catch (Exception e) {

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -82,7 +82,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   public static final String PROPERTY_NEXT_PAGE_TOKEN_PATH = "nextPageTokenPath";
   public static final String PROPERTY_NEXT_PAGE_URL_PARAMETER = "nextPageUrlParameter";
   public static final String PROPERTY_CUSTOM_PAGINATION_CODE = "customPaginationCode";
-  public static final String PROPERTY_WAIT_TIME_BETWEEN_PAGES = "waitTimeBetweenPages";
   public static final String PROPERTY_OAUTH2_ENABLED = "oauth2Enabled";
   public static final String PROPERTY_VERIFY_HTTPS = "verifyHttps";
   public static final String PROPERTY_KEYSTORE_FILE = "keystoreFile";
@@ -236,12 +235,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   @Description("[Pagination: Custom] A code which implements retrieving a next page url based " +
     "on previous page contents and headers.")
   protected String customPaginationCode;
-
-  @Name(PROPERTY_WAIT_TIME_BETWEEN_PAGES)
-  @Nullable
-  @Description("Time in milliseconds to wait between HTTP requests for the next page.")
-  @Macro
-  protected Long waitTimeBetweenPages;
 
   @Name(PROPERTY_VERIFY_HTTPS)
   @Description("If false, untrusted trust certificates (e.g. self signed), will not lead to an" +
@@ -424,11 +417,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
   @Nullable
   public String getCustomPaginationCode() {
     return customPaginationCode;
-  }
-
-  @Nullable
-  public Long getWaitTimeBetweenPages() {
-    return waitTimeBetweenPages;
   }
 
   public Boolean getVerifyHttps() {

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -155,6 +155,15 @@
           }
         },
         {
+          "widget-type": "number",
+          "label": "Wait Time Between Request (milliseconds)",
+          "name": "waitTimeBetweenPages",
+          "widget-attributes": {
+            "min": "0",
+            "default": "0"
+          }
+        },
+        {
           "widget-type": "keyvalue-dropdown",
           "label": "HTTP Errors Handling",
           "name": "httpErrorsHandling",


### PR DESCRIPTION
[Cherrypick] Added Wait Time Between Request Field in HTTP Sink
Commit : fbbd7b502564709ad28882ffec28b28e0a0ee8d2
PR: #153 

---

##  Added Wait Time Between Request Field in HTTP Sink

Jira : [Plugin-1740](https://cdap.atlassian.net/browse/PLUGIN-1740)

## Description
`Read Timeout (milliseconds)` field is incorrectly being used for delay between requests, a new field is added to define delay between requests.

## UI Fields changes

- A new UI field is added `Wait Time Between Request (milliseconds)`

<img width="998" alt="image" src="https://github.com/cloudsufi/http/assets/122770897/aa2664ef-32d8-4eee-9467-beb5e1db6dc6">

## Docs 

- docs for new field added
> Wait Time Between Request: Time in milliseconds to wait between HTTP requests. Defaults to 0.

## Code change
- Move wait between request field to base HTTP as same functionality is being used in HTTP source and HTTP sink 
- Change wrong field being used for delay.