### PR TITLE
[PLUGIN-1756] Fixed URL Validation

### DIFF
--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpInputFormatProvider.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpInputFormatProvider.java
@@ -71,8 +71,12 @@ public class HttpInputFormatProvider implements InputFormatProvider {
             new HttpResponse(client.executeHTTP(config.getUrl())));
           return DelimitedSchemaDetector.detectSchema(config, delimiter, rawStringPerLine, failureCollector);
         } catch (IOException e) {
+          String errorMessage = e.getMessage();
+          if (Strings.isNullOrEmpty(errorMessage) && e.getCause() != null) {
+            errorMessage = e.getCause().getMessage();
+          }
           failureCollector.addFailure(String.format("Error while reading the file to infer the schema. Error: %s",
-                                                   e.getMessage()), null);
+                                                    errorMessage), null);
         }
         return null;
       default:

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -36,8 +36,8 @@ import io.cdap.plugin.http.common.pagination.PaginationType;
 import io.cdap.plugin.http.common.pagination.page.PageFormat;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -570,7 +570,7 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     if (!containsMacro(PROPERTY_URL)) {
       try {
         // replace with placeholder with anything just during pagination
-        new URI(getUrl().replaceAll(PAGINATION_INDEX_PLACEHOLDER_REGEX, "0"));
+        new URL(getUrl().replaceAll(PAGINATION_INDEX_PLACEHOLDER_REGEX, "0"));
 
         // Validate HTTP Error Handling Map
         if (!containsMacro(PROPERTY_HTTP_ERROR_HANDLING)) {
@@ -591,7 +591,7 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
             }
           }
         }
-      } catch (URISyntaxException e) {
+      } catch (MalformedURLException e) {
         throw new InvalidConfigPropertyException(
           String.format("URL value is not valid: '%s'", getUrl()), e, PROPERTY_URL);
       }


### PR DESCRIPTION
## Fixed URL Validation

Jira : [PLUGIN-1756](https://cdap.atlassian.net/browse/PLUGIN-1756)

### Description

- When an invalid url is given, the validation logic only checks for a valid URI which may not raise errors for a lot of strings that are not valid URLs.
Replacing the validation to check for a URL will fix the proper error.

- Some exceptions are thrown by the http library without any error message string.
This is usually present on the cause of the error.

Adding this code snippet will fix null issue for other exceptions thrown by the library.

```java
String errorMessage = e.getMessage();
if (errorMessage == null && e.getCause() != null) {
errorMessage = e.getCause().getMessage();
}
```


### UI Field

- No Changes made to widget json.

### Docs

- No Changes made to docs.

### Code change

- Modified `HttpInputFormatProvider.java`
- Modified `BaseHttpSourceConfig.java`

### Unit Tests

- No Changes made to unit tests.
