### PR TITLE
[🍒][PLUGIN-1810] Add support for HTTP PATCH

### DIFF
--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPRecordWriter.java
@@ -22,9 +22,11 @@ import com.google.common.base.Strings;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.plugin.http.common.RetryPolicy;
+import io.cdap.plugin.http.common.error.ErrorHandling;
 import io.cdap.plugin.http.common.error.HttpErrorHandler;
 import io.cdap.plugin.http.common.error.RetryableErrorHandling;
 import io.cdap.plugin.http.common.http.HttpRequest;
+import io.cdap.plugin.http.common.http.HttpResponse;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -83,6 +85,7 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
   public static final String REQUEST_METHOD_POST = "POST";
   public static final String REQUEST_METHOD_PUT = "PUT";
   public static final String REQUEST_METHOD_DELETE = "DELETE";
+  public static final String REQUEST_METHOD_PATCH = "PATCH";
 
   private final HTTPSinkConfig config;
   private final MessageBuffer messageBuffer;
@@ -96,6 +99,7 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
   private final HttpErrorHandler httpErrorHandler;
   private final PollInterval pollInterval;
   private int httpStatusCode;
+  private String httpResponseBody;
   private static int retryCount;
 
   HTTPRecordWriter(HTTPSinkConfig config, Schema inputSchema) {
@@ -120,11 +124,13 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
   @Override
   public void write(StructuredRecord input, StructuredRecord unused) throws IOException {
     configURL = url;
-    if (config.getMethod().equals(REQUEST_METHOD_POST) || config.getMethod().equals(REQUEST_METHOD_PUT)) {
+    if (config.getMethod().equals(REQUEST_METHOD_POST) || config.getMethod().equals(REQUEST_METHOD_PUT) ||
+      config.getMethod().equals(REQUEST_METHOD_PATCH)) {
       messageBuffer.add(input);
     }
 
-    if (config.getMethod().equals(REQUEST_METHOD_PUT) || config.getMethod().equals(REQUEST_METHOD_DELETE)
+    if (config.getMethod().equals(REQUEST_METHOD_PUT) || config.getMethod().equals(REQUEST_METHOD_PATCH) ||
+      config.getMethod().equals(REQUEST_METHOD_DELETE)
       && !placeHolderList.isEmpty()) {
       configURL = updateURLWithPlaceholderValue(input);
     }
@@ -200,9 +206,9 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
       request.setHeaders(getRequestHeaders());
 
       response = httpClient.execute(request);
-
       httpStatusCode = response.getStatusLine().getStatusCode();
       LOG.debug("Response HTTP Status code: {}", httpStatusCode);
+      httpResponseBody = new HttpResponse(response).getBody();
 
     } catch (MalformedURLException | ProtocolException e) {
       throw new IllegalStateException("Error opening url connection. Reason: " + e.getMessage(), e);
@@ -277,7 +283,9 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
     headers.put("Instance-Follow-Redirects", String.valueOf(config.getFollowRedirects()));
     headers.put("charset", config.getCharset());
 
-    if (config.getMethod().equals(REQUEST_METHOD_POST) || config.getMethod().equals(REQUEST_METHOD_PUT)) {
+    if (config.getMethod().equals(REQUEST_METHOD_POST)
+      || config.getMethod().equals(REQUEST_METHOD_PATCH)
+      || config.getMethod().equals(REQUEST_METHOD_PUT)) {
       if (!headers.containsKey("Content-Type")) {
         headers.put("Content-Type", contentType);
       }
@@ -302,7 +310,8 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
    */
   private List<PlaceholderBean> getPlaceholderListFromURL() {
     List<PlaceholderBean> placeholderList = new ArrayList<>();
-    if (!(config.getMethod().equals(REQUEST_METHOD_PUT) || config.getMethod().equals(REQUEST_METHOD_DELETE))) {
+    if (!(config.getMethod().equals(REQUEST_METHOD_PUT) || config.getMethod().equals(REQUEST_METHOD_PATCH) ||
+      config.getMethod().equals(REQUEST_METHOD_DELETE))) {
       return placeholderList;
     }
     Pattern pattern = Pattern.compile(REGEX_HASHED_VAR);
@@ -351,6 +360,25 @@ public class HTTPRecordWriter extends RecordWriter<StructuredRecord, StructuredR
                                    "after the batch execution. " + e);
     }
     messageBuffer.clear();
+
+    ErrorHandling postRetryStrategy = httpErrorHandler.getErrorHandlingStrategy(httpStatusCode)
+      .getAfterRetryStrategy();
+
+    switch (postRetryStrategy) {
+      case SUCCESS:
+        break;
+      case STOP:
+        throw new IllegalStateException(String.format("Fetching from url '%s' returned status code '%d' and body '%s'",
+                                                      config.getUrl(), httpStatusCode, httpResponseBody));
+      case SKIP:
+      case SEND:
+        LOG.warn(String.format("Fetching from url '%s' returned status code '%d' and body '%s'",
+                               config.getUrl(), httpStatusCode, httpResponseBody));
+        break;
+      default:
+        throw new IllegalArgumentException(String.format("Unexpected http error handling: '%s'", postRetryStrategy));
+    }
+
   }
 
 }

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
@@ -80,7 +80,7 @@ public class HTTPSinkConfig extends BaseHttpConfig {
   private static final String REGEX_HASHED_VAR = "#(\\w+)";
   private static final String PLACEHOLDER = "#";
   private static final Set<String> METHODS = ImmutableSet.of(HttpMethod.GET, HttpMethod.POST,
-                                                             HttpMethod.PUT, HttpMethod.DELETE);
+                                                             HttpMethod.PUT, HttpMethod.DELETE, "PATCH");
 
   @Name(URL)
   @Description("The URL to post data to. Additionally, a placeholder like #columnName can be added to the URL that " +
@@ -462,7 +462,6 @@ public class HTTPSinkConfig extends BaseHttpConfig {
     if (!containsMacro(PROPERTY_RETRY_POLICY) && getRetryPolicy() == RetryPolicy.LINEAR) {
       assertIsSet(getLinearRetryInterval(), PROPERTY_LINEAR_RETRY_INTERVAL, "retry policy is linear");
     }
-
     if (!containsMacro(READ_TIMEOUT) && Objects.nonNull(readTimeout) && readTimeout < 0) {
       collector.addFailure("Read Timeout cannot be a negative number.", null)
         .withConfigProperty(READ_TIMEOUT);
@@ -494,7 +493,7 @@ public class HTTPSinkConfig extends BaseHttpConfig {
       return;
     }
     
-    if ((method.equals("PUT") || method.equals("DELETE")) && url.contains(PLACEHOLDER)) {
+    if ((method.equals("PUT") || method.equals("PATCH") || method.equals("DELETE")) && url.contains(PLACEHOLDER)) {
       Pattern pattern = Pattern.compile(REGEX_HASHED_VAR);
       Matcher matcher = pattern.matcher(url);
       List<String> fieldNames = fields.stream().map(field -> field.getName()).collect(Collectors.toList());

--- a/src/test/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfigTest.java
@@ -154,6 +154,18 @@ public class HTTPSinkConfigTest {
     Assert.assertTrue(collector.getValidationFailures().isEmpty());
   }
 
+  @Test()
+  public void testValidInputWithPlaceHoldersWithPATCH() {
+    Schema schema = Schema.recordOf("record",
+                                    Schema.Field.of("id", Schema.of(Schema.Type.LONG)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    String dynamicUrl = "http://example.com/api/v1/book/#id";
+    HTTPSinkConfig config = HTTPSinkConfig.newBuilder(VALID_CONFIG).setMethod("PATCH").setUrl(dynamicUrl).build();
+    MockFailureCollector collector = new MockFailureCollector("httpsinkwithvalidinputschema");
+    config.validateSchema(schema, collector);
+    Assert.assertTrue(collector.getValidationFailures().isEmpty());
+  }
+
   @Test(expected = ValidationException.class)
   public void testHTTPSinkWithNegativeBatchSize() {
     HTTPSinkConfig config = HTTPSinkConfig.newBuilder(VALID_CONFIG)

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -25,7 +25,8 @@
               "POST",
               "GET",
               "PUT",
-              "DELETE"
+              "DELETE",
+              "PATCH"
             ],
             "default": "POST"
           }

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -26,7 +26,8 @@
               "POST",
               "PUT",
               "DELETE",
-              "HEAD"
+              "HEAD",
+              "PATCH"
             ],
             "default": "GET"
           }

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -26,7 +26,8 @@
               "POST",
               "PUT",
               "DELETE",
-              "HEAD"
+              "HEAD",
+              "PATCH"
             ],
             "default": "GET"
           }


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - c7ef6c730ac32cb01d7d5672a98ba4db04b772a3

### PR:
 - #171 [ Reviewer @sahusanket]
---

## Add support for HTTP PATCH

Jira : [PLUGIN-1810](https://cdap.atlassian.net/browse/PLUGIN-1810)

### Description

- Adding support for  HTTP method PATCH in HTTP sink plugin.
- HTTP Source fail get schema on non 2xx response codes.
- HTTP Sink retry strategy fail on error fixed.

### UI Field

- Modified `HTTP-batchsink.json`
  - new method `PATCH` in drop down for `HTTP Method`
![image](https://github.com/user-attachments/assets/efa42f4b-bc1a-4d28-b157-399122b1ac62)

- Modified `HTTP-batchsource.json`
  - new method `PATCH` in drop down for `HTTP Method`
![image](https://github.com/user-attachments/assets/ee17fd79-70b8-4a29-bc4e-5f025e7cc863)


- Modified `HTTP-streamingsource.json`
  - new method `PATCH` in drop down for `HTTP Method`  
![image](https://github.com/user-attachments/assets/a4516948-c3be-45d0-a26b-8f953a10613c)

### Code change

- Modified `HTTPRecordWriter.java`
- Modified `HTTPSinkConfig.java`
- Modified `HttpInputFormatProvider.java`
  - Show error when get schema is called and non 2xx status code is received.
  - ![image](https://github.com/user-attachments/assets/7ff3d2c3-7d09-49de-bb9d-eae6494f5654)


### Unit Tests

- Modified `HTTPSinkConfigTest.java`
  - Added `testValidInputWithPlaceHoldersWithPATCH`  
![image](https://github.com/user-attachments/assets/d0efbf1c-f75f-41af-a9ce-d410008c2525)




[PLUGIN-1810]: https://cdap.atlassian.net/browse/PLUGIN-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ