### PR TITLE
[🍒][PLUGIN-1872] Added GrantType and Client Authentication for the HttpOauth2

### DIFF
--- a/docs/HTTP-batchsink.md
+++ b/docs/HTTP-batchsink.md
@@ -87,6 +87,36 @@ Skip on error - Ignores erroneous records.
 
 **Wait Time Between Request:** Time in milliseconds to wait between HTTP requests. Defaults to 0. (Macro enabled)
 
+### Authentication
+
+* **OAuth2**
+    * **Grant Type:** Which OAuth2 grant type flow is used. It can be Refresh Token or Client Credentials Flow.
+    * **Client Authentication:** Send OAuth2 Credentials in the Request Body or as Query Parameter or as Basic Auth
+      Header.
+    * **Auth URL:** Endpoint for the authorization server used to retrieve the authorization code.
+    * **Token URL:** Endpoint for the resource server, which exchanges the authorization code for an access token.
+    * **Client ID:** Client identifier obtained during the Application registration process.
+    * **Client Secret:** Client secret obtained during the Application registration process.
+    * **Scopes:** Scope of the access request, which might have multiple space-separated values.
+    * **Refresh Token:** Token used to receive accessToken, which is end product of OAuth2.
+* **Service Account** - service account key used for authorization
+    * **File Path**: Path on the local file system of the service account key used for
+      authorization. Can be set to 'auto-detect' when running on a Dataproc cluster.
+      When running on other clusters, the file must be present on every node in the cluster.
+    * **JSON**: Contents of the service account JSON file.
+    * **Scope**: The additional Google credential scopes required to access entered url, cloud-platform is included by
+      default, visit https://developers.google.com/identity/protocols/oauth2/scopes for more information.
+        * Scope example:
+
+```
+https://www.googleapis.com/auth/bigquery
+https://www.googleapis.com/auth/cloud-platform
+```
+
+* **Basic Authentication**
+    * **Username:** Username for basic authentication.
+    * **Password:** Password for basic authentication.
+
 ### HTTP Proxy
 
 **Proxy URL:** Proxy URL. Must contain a protocol, address and port.

--- a/docs/HTTP-batchsource.md
+++ b/docs/HTTP-batchsource.md
@@ -214,6 +214,9 @@ The newline delimiter cannot be within quotes.
 
 ### Authentication
 * **OAuth2**
+    * **Grant Type:** Which OAuth2 grant type flow is used. It can be Refresh Token or Client Credentials Flow.
+    * **Client Authentication:** Send OAuth2 Credentials in the Request Body or as Query Parameter or as Basic Auth
+      Header.
     * **Auth URL:** Endpoint for the authorization server used to retrieve the authorization code.
     * **Token URL:** Endpoint for the resource server, which exchanges the authorization code for an access token.
     * **Client ID:** Client identifier obtained during the Application registration process.

--- a/docs/HTTP-streamingsource.md
+++ b/docs/HTTP-streamingsource.md
@@ -209,6 +209,9 @@ can be omitted as long as the field is present in schema.
 
 ### Authentication
 * **OAuth2**
+    * **Grant Type:** Which OAuth2 grant type flow is used. It can be Refresh Token or Client Credentials Flow.
+    * **Client Authentication:** Send OAuth2 Credentials in the Request Body or as Query Parameter or as Basic Auth
+      Header.
     * **Auth URL:** Endpoint for the authorization server used to retrieve the authorization code.
     * **Token URL:** Endpoint for the resource server, which exchanges the authorization code for an access token.
     * **Client ID:** Client identifier obtained during the Application registration process.

--- a/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
+++ b/src/main/java/io/cdap/plugin/http/common/BaseHttpConfig.java
@@ -29,8 +29,8 @@ import io.cdap.plugin.http.common.http.OAuthUtil;
 
 import java.io.File;
 import java.util.Optional;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
-
 
 /**
  *  Base configuration for HTTP Source and HTTP Sink
@@ -48,6 +48,8 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     public static final String PROPERTY_PROXY_URL = "proxyUrl";
     public static final String PROPERTY_PROXY_USERNAME = "proxyUsername";
     public static final String PROPERTY_PROXY_PASSWORD = "proxyPassword";
+    public static final String PROPERTY_OAUTH2_GRANT_TYPE = "oauth2GrantType";
+    public static final String PROPERTY_OAUTH2_CLIENT_AUTHENTICATION = "oauth2ClientAuthentication";
 
     public static final String PROPERTY_AUTH_TYPE_LABEL = "Auth type";
 
@@ -92,6 +94,18 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
     @Description("Endpoint for the authorization server used to retrieve the authorization code.")
     @Macro
     protected String authUrl;
+
+    @Nullable
+    @Name(PROPERTY_OAUTH2_GRANT_TYPE)
+    @Description("Which Oauth2 grant type flow is used.")
+    @Macro
+    protected String oauth2GrantType;
+
+    @Nullable
+    @Name(PROPERTY_OAUTH2_CLIENT_AUTHENTICATION)
+    @Description("Send auth credentials in the request body or as query param.")
+    @Macro
+    protected String oauth2ClientAuthentication;
 
     @Nullable
     @Name(PROPERTY_TOKEN_URL)
@@ -206,6 +220,19 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
 
     public String getOAuth2Enabled() {
         return oauth2Enabled;
+    }
+
+    public OAuth2GrantType getOauth2GrantType() {
+        OAuth2GrantType grantType = OAuth2GrantType.getGrantType(oauth2GrantType);
+        return getEnumValueByString(OAuth2GrantType.class, grantType.getValue(),
+            PROPERTY_OAUTH2_GRANT_TYPE);
+    }
+
+    public OAuth2ClientAuthentication getOauth2ClientAuthentication() {
+        OAuth2ClientAuthentication clientAuthentication = OAuth2ClientAuthentication.getClientAuthentication(
+            oauth2ClientAuthentication);
+        return getEnumValueByString(OAuth2ClientAuthentication.class,
+            clientAuthentication.getValue(), PROPERTY_OAUTH2_CLIENT_AUTHENTICATION);
     }
 
     @Nullable
@@ -359,19 +386,7 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
         AuthType authType = getAuthType();
         switch (authType) {
             case OAUTH2:
-                String reasonOauth2 = "OAuth2 is enabled";
-                if (!containsMacro(PROPERTY_TOKEN_URL)) {
-                    assertIsSet(getTokenUrl(), PROPERTY_TOKEN_URL, reasonOauth2);
-                }
-                if (!containsMacro(PROPERTY_CLIENT_ID)) {
-                    assertIsSet(getClientId(), PROPERTY_CLIENT_ID, reasonOauth2);
-                }
-                if (!containsMacro((PROPERTY_CLIENT_SECRET))) {
-                    assertIsSet(getClientSecret(), PROPERTY_CLIENT_SECRET, reasonOauth2);
-                }
-                if (!containsMacro(PROPERTY_REFRESH_TOKEN)) {
-                    assertIsSet(getRefreshToken(), PROPERTY_REFRESH_TOKEN, reasonOauth2);
-                }
+                validateOAuth2Fields(failureCollector);
                 break;
             case SERVICE_ACCOUNT:
                 String reasonSA = "Service Account is enabled";
@@ -404,5 +419,66 @@ public abstract class BaseHttpConfig extends ReferencePluginConfig {
             throw new InvalidConfigPropertyException(
                     String.format("Property '%s' must be set, since %s", propertyName, reason), propertyName);
         }
+    }
+
+    public static void assertIsSetWithFailureCollector(Object propertyValue, String propertyName, String reason,
+                                                       FailureCollector failureCollector) {
+        if (propertyValue == null) {
+            failureCollector.addFailure(String.format("Property '%s' must be set, since %s", propertyName, reason),
+              null).withConfigProperty(propertyName);
+        }
+    }
+
+    private void validateOAuth2Fields(FailureCollector failureCollector) {
+        String reasonOauth2GrantType = String.format("OAuth2 is enabled and grant type is %s.",
+            getOauth2GrantType().getValue());
+        if (!containsMacro(PROPERTY_TOKEN_URL)) {
+            assertIsSetWithFailureCollector(getTokenUrl(), PROPERTY_TOKEN_URL,
+                reasonOauth2GrantType, failureCollector);
+        }
+        if (!containsMacro(PROPERTY_CLIENT_ID)) {
+            assertIsSetWithFailureCollector(getClientId(), PROPERTY_CLIENT_ID,
+                reasonOauth2GrantType, failureCollector);
+        }
+        if (!containsMacro(PROPERTY_CLIENT_SECRET)) {
+            assertIsSetWithFailureCollector(getClientSecret(), PROPERTY_CLIENT_SECRET,
+                reasonOauth2GrantType, failureCollector);
+        }
+        if (!containsMacro(PROPERTY_OAUTH2_CLIENT_AUTHENTICATION)) {
+            assertIsSetWithFailureCollector(getOauth2ClientAuthentication(),
+                PROPERTY_OAUTH2_CLIENT_AUTHENTICATION, reasonOauth2GrantType, failureCollector);
+        }
+        // in case of refresh token grant type, also check additional fields
+        if (OAuth2GrantType.REFRESH_TOKEN.equals(getOauth2GrantType())) {
+            if (!containsMacro(PROPERTY_REFRESH_TOKEN)) {
+                assertIsSetWithFailureCollector(getRefreshToken(), PROPERTY_REFRESH_TOKEN,
+                    reasonOauth2GrantType, failureCollector);
+            }
+        }
+        failureCollector.getOrThrowException();
+    }
+
+    /**
+     * Retrieves the corresponding enum constant of a given string value.
+     *
+     * <p>This method takes an enum class that implements {@code EnumWithValue} and searches for an
+     * enum constant that matches the provided string value. If no matching value is found, it throws
+     * an {@code InvalidConfigPropertyException}.</p>
+     *
+     * @param <T>          the type of enum that implements {@code EnumWithValue}
+     * @param enumClass    the class of the enum to search within
+     * @param stringValue  the string representation of the enum value
+     * @param propertyName the name of the property (used for error messages)
+     * @return the corresponding enum constant if a match is found
+     * @throws InvalidConfigPropertyException if the string value does not match any enum constant
+     */
+    public static <T extends EnumWithValue> T
+    getEnumValueByString(Class<T> enumClass, String stringValue, String propertyName) {
+        return Stream.of(enumClass.getEnumConstants())
+            .filter(keyType -> keyType.getValue().equalsIgnoreCase(stringValue))
+            .findAny()
+            .orElseThrow(() -> new InvalidConfigPropertyException(
+                String.format("Unsupported value for '%s': '%s'", propertyName, stringValue),
+                propertyName));
     }
 }

--- a/src/main/java/io/cdap/plugin/http/common/OAuth2ClientAuthentication.java
+++ b/src/main/java/io/cdap/plugin/http/common/OAuth2ClientAuthentication.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.common;
+
+import java.util.Objects;
+
+/**
+ * Enum encoding the handled Oauth2 Client Authentication
+ */
+public enum OAuth2ClientAuthentication implements EnumWithValue {
+  BODY("body", "Body"),
+  REQUEST_PARAMETER("request_parameter", "Request Parameter"),
+  BASIC_AUTH_HEADER("basic_auth_header", "Basic Auth Header");
+
+  private final String value;
+  private final String label;
+
+  OAuth2ClientAuthentication(String value, String label) {
+    this.value = value;
+    this.label = label;
+  }
+
+  /**
+   * Determines the OAuth2 client authentication method based on the provided input.
+   *
+   * <p>This method checks if the given client authentication type matches the predefined
+   *  authentication type. If it matches, the method returns the same authentication. Otherwise,
+   * it defaults to BASIC_AUTH_HEADER authentication.</p>
+   *
+   * @param clientAuthentication The client authentication type as a {@link String}. It can be
+   *                             either the value or the label of the authentication method.
+   * @return {@link OAuth2ClientAuthentication} The corresponding authentication type.
+   */
+  public static OAuth2ClientAuthentication getClientAuthentication(String clientAuthentication) {
+    if (Objects.equals(clientAuthentication, BODY.getValue()) || Objects.equals(
+        clientAuthentication, BODY.getLabel())) {
+      return BODY;
+    } else if (Objects.equals(clientAuthentication, REQUEST_PARAMETER.getValue()) || Objects.equals(
+      clientAuthentication, REQUEST_PARAMETER.getLabel())) {
+      return REQUEST_PARAMETER;
+    } else {
+      return BASIC_AUTH_HEADER;
+    }
+  }
+
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/http/common/OAuth2GrantType.java
+++ b/src/main/java/io/cdap/plugin/http/common/OAuth2GrantType.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.http.common;
+
+import java.util.Objects;
+
+/**
+ * Enum encoding the handled Oauth2 Grant Types
+ */
+public enum OAuth2GrantType implements EnumWithValue {
+  REFRESH_TOKEN("refresh_token", "Refresh Token"),
+  CLIENT_CREDENTIALS("client_credentials", "Client Credentials");
+
+  private final String value;
+  private final String label;
+
+  OAuth2GrantType(String value, String label) {
+    this.value = value;
+    this.label = label;
+  }
+
+  /**
+   * Determines the OAuth2 grant type based on the provided string value.
+   *
+   * <p>This method checks whether the given OAuth2 grant type string matches
+   * the CLIENT_CREDENTIALS grant type based on its value or label. If it matches,
+   * CLIENT_CREDENTIALS is returned; otherwise, REFRESH_TOKEN is returned as the default.</p>
+   *
+   * @param oauth2GrantType The OAuth2 grant type as a string.
+   * @return The corresponding {@link OAuth2GrantType}, either CLIENT_CREDENTIALS or REFRESH_TOKEN.
+   */
+  public static OAuth2GrantType getGrantType(String oauth2GrantType) {
+    if (Objects.equals(oauth2GrantType, CLIENT_CREDENTIALS.getValue()) || Objects.equals(
+        oauth2GrantType, CLIENT_CREDENTIALS.getLabel())) {
+      return CLIENT_CREDENTIALS;
+    } else {
+      return REFRESH_TOKEN;
+    }
+  }
+  
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  public String getLabel() {
+    return label;
+  }
+
+  @Override
+  public String toString() {
+    return this.getValue();
+  }
+}

--- a/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/HttpClient.java
@@ -32,6 +32,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 
 import java.io.Closeable;
@@ -132,7 +133,14 @@ public class HttpClient implements Closeable {
       httpClientBuilder.setProxy(proxyHost);
     }
     httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-
+    ArrayList<Header> clientHeaders = new ArrayList<>();
+    // If OAuth2 is enabled, fetch an access token and add it as an Authorization header.
+    if (Boolean.TRUE.equals(config.getOauth2Enabled())) {
+      AccessToken oauth2AccessToken = OAuthUtil.getAccessToken(httpClientBuilder.build(), config);
+      clientHeaders.add(new BasicHeader("Authorization",
+          String.format("Bearer %s", oauth2AccessToken.getTokenValue())));
+    }
+    httpClientBuilder.setDefaultHeaders(clientHeaders);
     return httpClientBuilder.build();
   }
 

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -21,13 +21,17 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonElement;
 import io.cdap.plugin.http.common.BaseHttpConfig;
+import io.cdap.plugin.http.common.OAuth2GrantType;
 import io.cdap.plugin.http.common.pagination.page.JSONUtil;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 
 import java.io.ByteArrayInputStream;
@@ -37,14 +41,24 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
+import java.util.List;
 import javax.annotation.Nullable;
 
 /**
  * A class which contains utilities to make OAuth2 specific calls.
  */
 public class OAuthUtil {
+
+  private static final String PARAM_GRANT_TYPE = "grant_type";
+  private static final String PARAM_CLIENT_ID = "client_id";
+  private static final String PARAM_CLIENT_SECRET = "client_secret";
+  private static final String PARAM_REFRESH_TOKEN = "refresh_token";
+  private static final String PARAM_SCOPE = "scope";
 
   /**
    * Get Authorization header based on the config parameters provided
@@ -70,10 +84,123 @@ public class OAuthUtil {
         return OAuthUtil.getAccessTokenByServiceAccount(config);
       case OAUTH2:
         try (CloseableHttpClient client = HttpClients.createDefault()) {
-          return OAuthUtil.getAccessTokenByRefreshToken(client, config);
+          return getAccessToken(client, config);
         }
     }
     return null;
+  }
+
+  /**
+   * Retrieves an OAuth 2.0 access token based on the specified grant type.
+   *
+   * <p>This method supports obtaining an access token using either the {@code REFRESH_TOKEN}
+   * or {@code CLIENT_CREDENTIALS} grant type. If an invalid grant type is provided, an
+   * {@link IOException} is thrown.</p>
+   *
+   * @param httpclient the {@link CloseableHttpClient} instance used to execute HTTP requests.
+   * @param config     the {@link BaseHttpConfig} instance containing OAuth 2.0 configuration
+   *                   details.
+   * @return an {@link AccessToken} object containing the retrieved access token.
+   * @throws IOException if an error occurs during the HTTP request or if the grant type is
+   *                     invalid.
+   */
+  public static AccessToken getAccessToken(CloseableHttpClient httpclient, BaseHttpConfig config)
+      throws IOException {
+    switch (config.getOauth2GrantType()) {
+      case REFRESH_TOKEN:
+        return getAccessTokenByRefreshToken(httpclient, config);
+      case CLIENT_CREDENTIALS:
+        return getAccessTokenByClientCredentials(httpclient, config);
+      default:
+        throw new IllegalArgumentException(
+            String.format("Invalid Grant Type: %s. Cannot retrieve access token.",
+                config.getOauth2GrantType()));
+    }
+  }
+
+  /**
+   * Retrieves an OAuth2 access token using the Client Credentials grant type.
+   *
+   * <p>This method constructs an HTTP POST request to fetch an access token from the authorization
+   * server. The client authentication method (either "BODY" or "REQUEST" or "BASIC_AUTH_HEADER") determines whether
+   * client credentials are sent in the request body or as query parameters or as basic auth header.</p>
+   *
+   * <p>Steps:
+   * 1. If client authentication is set to "BODY": - Constructs a URI using the token URL. - Adds
+   * necessary parameters (scope, grant_type, client_id, client_secret) in the request body. -
+   * Creates an HTTP POST request and sets the entity with encoded parameters.
+   * <br>
+   * 2. If client authentication is set to "REQUEST": - Constructs a URI with client credentials as
+   * query parameters. - Creates an HTTP POST request with the URI.
+   * <br>
+   * 3. If client authentication is set to "BASIC_AUTH_HEADER": - Constructs a URI with client credentials first
+   * concatenated and encoded to Base64 and passed a Basic Authorization Header and
+   * grant type and scope as part of body.
+   *  <br>
+   * 4. Calls `fetchAccessToken(httpclient,httppost)` to execute the request and retrieve the
+   * token.
+   *
+   * @param httpclient           The HTTP client to execute the request.
+   * @return An AccessToken object containing the token and expiration details.
+   * @throws IOException              If an error occurs while executing the request.
+   * @throws IllegalArgumentException If the token URL cannot be built properly.
+   */
+  public static AccessToken getAccessTokenByClientCredentials(CloseableHttpClient httpclient,
+      BaseHttpConfig config) throws IOException {
+    URI uri;
+    HttpPost httppost;
+
+    try {
+      List<BasicNameValuePair> nameValuePairs = new ArrayList<>();
+      switch (config.getOauth2ClientAuthentication()) {
+        case BODY:
+          uri = new URIBuilder(config.getTokenUrl()).build();
+          nameValuePairs.add(
+            new BasicNameValuePair(PARAM_GRANT_TYPE, OAuth2GrantType.CLIENT_CREDENTIALS.getValue()));
+          nameValuePairs.add(new BasicNameValuePair(PARAM_CLIENT_ID, config.getClientId()));
+          nameValuePairs.add(new BasicNameValuePair(PARAM_CLIENT_SECRET, config.getClientSecret()));
+          if (!Strings.isNullOrEmpty(config.getScopes())) {
+            nameValuePairs.add(new BasicNameValuePair(PARAM_SCOPE, config.getScopes()));
+          }
+          httppost = new HttpPost(uri);
+          httppost.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+          break;
+
+        case REQUEST_PARAMETER:
+          URIBuilder uriBuilder = new URIBuilder(config.getTokenUrl()).setParameter(PARAM_CLIENT_ID,
+                                                                                    config.getClientId())
+            .setParameter(PARAM_CLIENT_SECRET, config.getClientSecret())
+            .setParameter(PARAM_GRANT_TYPE, OAuth2GrantType.CLIENT_CREDENTIALS.getValue());
+          if (!Strings.isNullOrEmpty(config.getScopes())) {
+            uriBuilder.setParameter(PARAM_SCOPE, config.getScopes());
+          }
+          uri = uriBuilder.build();
+          httppost = new HttpPost(uri);
+          break;
+          
+        case BASIC_AUTH_HEADER:
+          String credentials = config.getClientId() + ":" + config.getClientSecret();
+          String basicAuthHeader = String.format("Basic %s", Base64.getEncoder()
+            .encodeToString(credentials.getBytes(StandardCharsets.UTF_8)));
+          nameValuePairs.add(new BasicNameValuePair(PARAM_SCOPE, config.getScopes()));
+          nameValuePairs.add(new BasicNameValuePair(PARAM_GRANT_TYPE, OAuth2GrantType.CLIENT_CREDENTIALS.getValue()));
+          uri = new URIBuilder(config.getTokenUrl()).build();
+          httppost = new HttpPost(uri);
+          httppost.setHeader(new BasicHeader("Authorization", basicAuthHeader));
+          httppost.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+          break;
+          
+        default:
+          throw new IllegalArgumentException(
+            String.format("Unknown OAuth client authentication '%s'",
+                          config.getOauth2ClientAuthentication().getValue()));
+      }
+      return fetchAccessToken(httpclient, httppost);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(
+          "Failed to build access token URI for OAuth2 with grant type = "
+              + OAuth2GrantType.CLIENT_CREDENTIALS.getValue(), e);
+    }
   }
 
   /**
@@ -110,30 +237,54 @@ public class OAuthUtil {
     URI uri;
     try {
       uri = new URIBuilder(config.getTokenUrl())
-              .setParameter("client_id", config.getClientId())
-              .setParameter("client_secret", config.getClientSecret())
-              .setParameter("refresh_token", config.getRefreshToken())
-              .setParameter("grant_type", "refresh_token")
+        .setParameter(PARAM_CLIENT_ID, config.getClientId())
+        .setParameter(PARAM_CLIENT_SECRET, config.getClientSecret())
+        .setParameter(PARAM_REFRESH_TOKEN, config.getRefreshToken())
+        .setParameter(PARAM_GRANT_TYPE, OAuth2GrantType.REFRESH_TOKEN.getValue())
               .build();
+      HttpPost httppost = new HttpPost(uri);
+      return fetchAccessToken(httpclient, httppost);
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Failed to build token URI for OAuth2", e);
     }
+  }
 
-    HttpPost httppost = new HttpPost(uri);
+  /**
+   * Fetches an OAuth2 access token by executing an HTTP POST request.
+   *
+   * @param httpclient The HTTP client used to execute the request.
+   * @param httppost   The HTTP POST request containing the authentication details.
+   * @return An AccessToken object containing the token string and expiration date.
+   * @throws IOException If an error occurs while executing the request or processing the response.
+   */
+  private static AccessToken fetchAccessToken(CloseableHttpClient httpclient, HttpPost httppost)
+      throws IOException {
     CloseableHttpResponse response = httpclient.execute(httppost);
     String responseString = EntityUtils.toString(response.getEntity(), "UTF-8");
 
     JsonElement accessTokenElement = JSONUtil.toJsonObject(responseString).get("access_token");
     if (accessTokenElement == null) {
-      throw new IllegalArgumentException("Access token not found");
+      String errorResponse;
+      if (response.getStatusLine() != null) {
+        errorResponse = String.format("Response Code: '%s', Error Message:'%s'.",
+                                      response.getStatusLine().getStatusCode(),
+                                      response.getStatusLine().getReasonPhrase());
+      } else {
+        errorResponse = response.toString();
+      }
+      throw new IllegalArgumentException(
+        "Access token not found with Details: " + errorResponse);
     }
 
     JsonElement expiresInElement = JSONUtil.toJsonObject(responseString).get("expires_in");
     Date expiresInDate = null;
     if (expiresInElement != null) {
-      long expiresAtMilliseconds = System.currentTimeMillis()
-              + (long) (expiresInElement.getAsInt() * 1000) - 60000L;
-      expiresInDate = new Date(expiresAtMilliseconds);
+      Instant now = Instant.now();
+      Duration expiresIn = Duration.ofSeconds(expiresInElement.getAsInt());
+      Duration buffer = Duration.ofMinutes(1);
+
+      Instant expiresAt = now.plus(expiresIn).minus(buffer);
+      expiresInDate = Date.from(expiresAt);
     }
 
     return new AccessToken(accessTokenElement.getAsString(), expiresInDate);

--- a/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
+++ b/src/main/java/io/cdap/plugin/http/sink/batch/HTTPSinkConfig.java
@@ -28,7 +28,6 @@ import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.plugin.common.ReferenceNames;
 
 import io.cdap.plugin.http.common.BaseHttpConfig;
-import io.cdap.plugin.http.common.EnumWithValue;
 import io.cdap.plugin.http.common.RetryPolicy;
 import io.cdap.plugin.http.common.error.ErrorHandling;
 import io.cdap.plugin.http.common.error.HttpErrorHandlerEntity;
@@ -48,7 +47,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.ws.rs.HttpMethod;
 
@@ -340,15 +338,6 @@ public class HTTPSinkConfig extends BaseHttpConfig {
       return RetryPolicy.EXPONENTIAL;
     }
     return getEnumValueByString(RetryPolicy.class, retryPolicy, PROPERTY_RETRY_POLICY);
-  }
-
-  private static <T extends EnumWithValue> T
-  getEnumValueByString(Class<T> enumClass, String stringValue, String propertyName) {
-    return Stream.of(enumClass.getEnumConstants())
-      .filter(keyType -> keyType.getValue().equalsIgnoreCase(stringValue))
-      .findAny()
-      .orElseThrow(() -> new InvalidConfigPropertyException(
-        String.format("Unsupported value for '%s': '%s'", propertyName, stringValue), propertyName));
   }
 
   @Nullable

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -23,7 +23,6 @@ import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.HttpClient;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
@@ -75,7 +74,8 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     if (!containsMacro(PROPERTY_CLIENT_ID) && !containsMacro(PROPERTY_CLIENT_SECRET) &&
       !containsMacro(PROPERTY_TOKEN_URL) && !containsMacro(PROPERTY_REFRESH_TOKEN) &&
       !containsMacro(PROPERTY_PROXY_PASSWORD) && !containsMacro(PROPERTY_PROXY_USERNAME) &&
-      !containsMacro(PROPERTY_PROXY_URL)) {
+      !containsMacro(PROPERTY_PROXY_URL) && !containsMacro(PROPERTY_OAUTH2_CLIENT_AUTHENTICATION) &&
+      !containsMacro(PROPERTY_OAUTH2_GRANT_TYPE)) {
       HttpClientBuilder httpclientBuilder = HttpClients.custom();
       if (!Strings.isNullOrEmpty(getProxyUrl())) {
         HttpHost proxyHost = HttpHost.create(getProxyUrl());
@@ -89,7 +89,7 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
       }
 
       try (CloseableHttpClient closeableHttpClient = httpclientBuilder.build()) {
-        OAuthUtil.getAccessTokenByRefreshToken(closeableHttpClient, this);
+        OAuthUtil.getAccessToken(closeableHttpClient, this);
       } catch (JsonSyntaxException | HttpHostConnectException e) {
         String errorMessage = "Error occurred during credential validation : " + e.getMessage();
         collector.addFailure(errorMessage, null);
@@ -154,6 +154,8 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     this.proxyUrl = builder.proxyUrl;
     this.proxyUsername = builder.proxyUsername;
     this.proxyPassword = builder.proxyPassword;
+    this.oauth2GrantType = builder.oauth2GrantType;
+    this.oauth2ClientAuthentication = builder.oauth2ClientAuthentication;
   }
 
   public static HttpBatchSourceConfigBuilder builder() {
@@ -193,7 +195,19 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     private String proxyPassword;
     private String username;
     private String password;
+    private String oauth2GrantType;
+    private String oauth2ClientAuthentication;
 
+    public HttpBatchSourceConfigBuilder setOauth2GrantType(String oauth2GrantType) {
+      this.oauth2GrantType = oauth2GrantType;
+      return this;
+    }
+
+    public HttpBatchSourceConfigBuilder setOauth2ClientAuthentication(
+        String oauth2ClientAuthentication) {
+      this.oauth2ClientAuthentication = oauth2ClientAuthentication;
+      return this;
+    }
 
     public HttpBatchSourceConfigBuilder setReferenceName (String referenceName) {
       this.referenceName = referenceName;

--- a/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/common/BaseHttpSourceConfig.java
@@ -749,16 +749,6 @@ public abstract class BaseHttpSourceConfig extends BaseHttpConfig {
     }
   }
 
-
-  public static <T extends EnumWithValue> T
-  getEnumValueByString(Class<T> enumClass, String stringValue, String propertyName) {
-    return Stream.of(enumClass.getEnumConstants())
-      .filter(keyType -> keyType.getValue().equalsIgnoreCase(stringValue))
-      .findAny()
-      .orElseThrow(() -> new InvalidConfigPropertyException(
-        String.format("Unsupported value for '%s': '%s'", propertyName, stringValue), propertyName));
-  }
-
   @Nullable
   public static Long toLong(String value, String propertyName) {
     if (Strings.isNullOrEmpty(value)) {

--- a/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
@@ -25,7 +25,6 @@ import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.common.pagination.BaseHttpPaginationIterator;
 import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
 import io.cdap.plugin.http.source.batch.HttpBatchSourceConfig;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -93,13 +92,14 @@ public class HttpBatchSourceConfigTest {
   @Test
   public void testValidateOAuth2() throws Exception {
     FailureCollector collector = new MockFailureCollector();
-    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
-      .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
-      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
-      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
-        "exponential").build();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential")
+        .setOauth2GrantType("refresh_token").build();
     PowerMockito.mockStatic(PaginationIteratorFactory.class);
     BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(BaseHttpPaginationIterator.class);
     PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
@@ -128,7 +128,7 @@ public class HttpBatchSourceConfigTest {
       .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
       setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
         "exponential").setProxyUrl("https://proxy").setProxyUsername("proxyuser").setProxyPassword("proxypassword")
-      .build();
+        .setOauth2GrantType("refresh_token").build();
     HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
     CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
     HttpHost proxy = PowerMockito.mock(HttpHost.class);
@@ -155,11 +155,11 @@ public class HttpBatchSourceConfigTest {
     FailureCollector collector = new MockFailureCollector();
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
-      .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
+        .setFormat("JSON").setErrorHandling(StringUtils.EMPTY)
       .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
       .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
       setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
-        "exponential").build();
+            "exponential").setOauth2GrantType("refresh_token").build();
     CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
@@ -225,4 +225,324 @@ public class HttpBatchSourceConfigTest {
       .getValidationFailures().get(0).getMessage());
   }
 
+  // Client credentials unit test cases for "Body" authentication
+  @Test
+  public void testValidateOAuth2WithClientCredentialsAndBodyAuthentication() throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
+        .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
+        .setOauth2ClientAuthentication("body").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+        BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+        .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByClientCredentials(Mockito.any(), Mockito.any()))
+        .thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxyWithClientCredentialsAndBodyAuthentication()
+      throws IOException {
+    FailureCollector collector = new MockFailureCollector();
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
+        .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+        .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("body").build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(
+        HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).setProxy(proxy)
+            .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any()))
+        .thenReturn(accessToken);
+    config.validate(collectorMock);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequestForClientCredentialsAndBodyAuthentication()
+      throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential")
+        .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("body").build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n"
+        + "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n"
+        + "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+        BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+        .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    try {
+      config.validate(collector);
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(1, collector.getValidationFailures().size());
+    }
+  }
+
+  // Client credentials unit test cases for "Request Parameter" authentication
+  @Test
+  public void testValidateOAuth2WithClientCredentialsAndRequestParamAuthentication()
+      throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
+        .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
+        .setOauth2ClientAuthentication("request_parameter").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+        BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+        .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByClientCredentials(Mockito.any(), Mockito.any()))
+        .thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxyWithClientCredentialsAndRequestParamAuthentication()
+      throws IOException {
+    FailureCollector collector = new MockFailureCollector();
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
+        .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+        .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("request_parameter")
+        .build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(
+        HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).setProxy(proxy)
+            .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any()))
+        .thenReturn(accessToken);
+    config.validate(collectorMock);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequestForClientCredAndRequestParamAuthentication()
+      throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+        .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+        .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential")
+        .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("request_parameter")
+        .build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n"
+        + "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n"
+        + "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+        BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+        .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    try {
+      config.validate(collector);
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(1, collector.getValidationFailures().size());
+    }
+  }
+
+  // Client credentials unit test cases for "Basic Auth Header" authentication
+  @Test
+  public void testValidateOAuth2WithClientCredentialsAndBasicAuthHeaderAuthentication()
+    throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+      .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+      .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
+      .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
+      .setOauth2ClientAuthentication("basic_auth_header").build();
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+      BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByClientCredentials(Mockito.any(), Mockito.any()))
+      .thenReturn(accessToken);
+    config.validate(collector);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+
+  @Test
+  public void testValidateOAuth2CredentialsWithProxyWithClientCredentialsAndBasicAuthHeaderAuthentication()
+    throws IOException {
+    FailureCollector collector = new MockFailureCollector();
+    FailureCollector collectorMock = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+      .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+      .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+      .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
+      .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
+      .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("basic_auth_header")
+      .build();
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    HttpHost proxy = PowerMockito.mock(HttpHost.class);
+    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+    httpClientBuilder.setProxy(proxy);
+    PowerMockito.mockStatic(HttpClients.class);
+    CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+    Mockito.when(HttpClients.createDefault()).thenReturn(closeableHttpClient);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(
+      HttpClients.custom().setDefaultCredentialsProvider(credentialsProvider).setProxy(proxy)
+        .build()).thenReturn(closeableHttpClient);
+    AccessToken accessToken = Mockito.mock(AccessToken.class);
+    Mockito.when(accessToken.getTokenValue()).thenReturn("1234");
+    PowerMockito.mockStatic(OAuthUtil.class);
+    Mockito.when(OAuthUtil.getAccessTokenByRefreshToken(Mockito.any(), Mockito.any()))
+      .thenReturn(accessToken);
+    config.validate(collectorMock);
+    Assert.assertEquals(0, collector.getValidationFailures().size());
+  }
+
+  @Test
+  public void testValidateCredentialsOAuth2WithInvalidAccessTokenRequestForClientCredAndBasicAuthHeaderAuthentication()
+    throws Exception {
+    FailureCollector collector = new MockFailureCollector();
+    HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
+      .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
+      .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+      .setTokenUrl("https//:token").setRetryPolicy("exponential")
+      .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("basic_auth_header")
+      .build();
+    CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
+    CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
+    Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
+    HttpEntity entity = Mockito.mock(HttpEntity.class);
+    Mockito.when(httpResponse.getEntity()).thenReturn(entity);
+    PowerMockito.mockStatic(EntityUtils.class);
+    String response = "  <title>Error 404 (Not Found)!!1</title>\n"
+      + "  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>\n"
+      + "  <p><b>404.</b> <ins>That’s an error.</ins>\n";
+
+    Mockito.when(EntityUtils.toString(entity, "UTF-8")).thenReturn(response);
+    PowerMockito.mockStatic(PaginationIteratorFactory.class);
+    BaseHttpPaginationIterator baseHttpPaginationIterator = Mockito.mock(
+      BaseHttpPaginationIterator.class);
+    PowerMockito.when(PaginationIteratorFactory.createInstance(Mockito.any(), Mockito.any()))
+      .thenReturn(baseHttpPaginationIterator);
+    PowerMockito.when(baseHttpPaginationIterator.supportsSkippingPages()).thenReturn(true);
+    PowerMockito.mockStatic(HttpClients.class);
+    HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
+    Mockito.when(HttpClients.custom()).thenReturn(httpClientBuilder);
+    Mockito.when(httpClientBuilder.build()).thenReturn(httpClientMock);
+    config.validate(collector);
+    Assert.assertEquals(1, collector.getValidationFailures().size());
+  }
 }

--- a/widgets/HTTP-batchsink.json
+++ b/widgets/HTTP-batchsink.json
@@ -276,6 +276,31 @@
           }
         },
         {
+          "widget-type": "select",
+          "label": "Grant Type",
+          "name": "oauth2GrantType",
+          "widget-attributes": {
+            "values": [
+              "Refresh Token",
+              "Client Credentials"
+            ],
+            "default": "Refresh Token"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Client Authentication",
+          "name": "oauth2ClientAuthentication",
+          "widget-attributes": {
+            "values": [
+              "Body",
+              "Request Parameter",
+              "Basic Auth Header"
+            ],
+            "default": "Body"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Auth URL",
           "name": "authUrl"
@@ -467,6 +492,30 @@
       ]
     },
     {
+      "name": "Show Client Authentication when with Grant type is Client Credentials",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType == 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "oauth2ClientAuthentication",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Show Refresh_Token when Grant type is 'Refresh Token' or NULL for older version pipeline",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType != 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "refreshToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "Authenticate with OAuth2",
       "condition": {
         "property": "authType",
@@ -474,6 +523,10 @@
         "value": "oAuth2"
       },
       "show": [
+        {
+          "name": "oauth2GrantType",
+          "type": "property"
+        },
         {
           "name": "authUrl",
           "type": "property"
@@ -492,10 +545,6 @@
         },
         {
           "name": "scopes",
-          "type": "property"
-        },
-        {
-          "name": "refreshToken",
           "type": "property"
         }
       ]

--- a/widgets/HTTP-batchsource.json
+++ b/widgets/HTTP-batchsource.json
@@ -166,6 +166,31 @@
           }
         },
         {
+          "widget-type": "select",
+          "label": "Grant Type",
+          "name": "oauth2GrantType",
+          "widget-attributes": {
+            "values": [
+              "Refresh Token",
+              "Client Credentials"
+            ],
+            "default": "Refresh Token"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Client Authentication",
+          "name": "oauth2ClientAuthentication",
+          "widget-attributes": {
+            "values": [
+              "Body",
+              "Request Parameter",
+              "Basic Auth Header"
+            ],
+            "default": "Body"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Auth URL",
           "name": "authUrl"
@@ -721,6 +746,30 @@
       ]
     },
     {
+      "name": "Show Client Authentication when with Grant type is Client Credentials",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType == 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "oauth2ClientAuthentication",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Show Refresh Token when Grant type is 'Refresh Token' or NULL for older version pipeline",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType != 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "refreshToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "Authenticate with OAuth2",
       "condition": {
         "property": "authType",
@@ -728,6 +777,10 @@
         "value": "oAuth2"
       },
       "show": [
+        {
+          "name": "oauth2GrantType",
+          "type": "property"
+        },
         {
           "name": "authUrl",
           "type": "property"
@@ -746,10 +799,6 @@
         },
         {
           "name": "scopes",
-          "type": "property"
-        },
-        {
-          "name": "refreshToken",
           "type": "property"
         }
       ]

--- a/widgets/HTTP-streamingsource.json
+++ b/widgets/HTTP-streamingsource.json
@@ -134,6 +134,31 @@
           }
         },
         {
+          "widget-type": "select",
+          "label": "Grant Type",
+          "name": "oauth2GrantType",
+          "widget-attributes": {
+            "values": [
+              "Refresh Token",
+              "Client Credentials"
+            ],
+            "default": "Refresh Token"
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Client Authentication",
+          "name": "oauth2ClientAuthentication",
+          "widget-attributes": {
+            "values": [
+              "Body",
+              "Request Parameter",
+              "Basic Auth Header"
+            ],
+            "default": "Body"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Auth URL",
           "name": "authUrl"
@@ -677,6 +702,30 @@
       ]
     },
     {
+      "name": "Show Client Authentication when with Grant type is Client Credentials",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType == 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "oauth2ClientAuthentication",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Show Refresh_Token when Grant type is 'Refresh Token' or NULL for older version pipeline",
+      "condition": {
+        "expression": "authType == 'oAuth2' && oauth2GrantType != 'Client Credentials'"
+      },
+      "show": [
+        {
+          "name": "refreshToken",
+          "type": "property"
+        }
+      ]
+    },
+    {
       "name": "Authenticate with OAuth2",
       "condition": {
         "property": "authType",
@@ -684,6 +733,10 @@
         "value": "oAuth2"
       },
       "show": [
+        {
+          "name": "oauth2GrantType",
+          "type": "property"
+        },
         {
           "name": "authUrl",
           "type": "property"
@@ -702,10 +755,6 @@
         },
         {
           "name": "scopes",
-          "type": "property"
-        },
-        {
-          "name": "refreshToken",
           "type": "property"
         }
       ]


### PR DESCRIPTION
🍒 [cherrypick]

### Commits :
 - 7ca628d3240f67c2b234d44b8f14537afe20752c
 - 697f36f942445ef523578fe6d05d845250745522
 
### PR:
 - #187 [ Reviewer @itsankit-google ]
 - #192 [ Reviewer @itsankit-google ]
 
 ---
 
 https://cdap.atlassian.net/browse/PLUGIN-1872

### **Update UI:**
**1. Grant Type: Refresh Token**
![image](https://github.com/user-attachments/assets/b51d771d-c558-476f-b78c-64a89f1f7b4d)
![image](https://github.com/user-attachments/assets/b0b46cdc-fe6d-416b-9d98-43006ff6f57c)


**2. Grant Type: Client Credentials and Client Authentication: Body**
![image](https://github.com/user-attachments/assets/d5b218cc-67d2-4a92-bf63-6f865d89fd38)
![image](https://github.com/user-attachments/assets/0d2990bd-8d49-463d-a58b-3586572657c4)


**3. Grant Type: Client Credentials and Client Authentication: Request parameter**
![image](https://github.com/user-attachments/assets/e0405967-e610-4fbb-878d-95c12578b384)
![image](https://github.com/user-attachments/assets/d512e974-dab5-4274-90fa-9ec13776e7cc)



### **Older UI vs When pipeline upgraded to latest build**
1. Older Pipeline:
![image](https://github.com/user-attachments/assets/7c8af707-8b0f-47e4-904c-0dec55afa10c)

3. Older pipeline upgraded to latest UI:
![image](https://github.com/user-attachments/assets/62c0b01c-f0c6-4ffd-b092-e51c9a5cad9c)
![image](https://github.com/user-attachments/assets/d9356a90-14fb-477f-90ca-cc1ac3e76491)


---

[PLUGIN-1872] Basic Auth Header changes for client_credentials grant type.

This is an additional change on PR https://github.com/data-integrations/http/pull/187 based on customer feedback

[PLUGIN-1872]: https://cdap.atlassian.net/browse/PLUGIN-1872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1528" alt="Screenshot 2025-04-10 at 6 15 44 PM" src="https://github.com/user-attachments/assets/b8273d98-7775-485b-a59e-d078e3197573" />


