### PR TITLE
Update cdap version to 6.11.0 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
 
   <properties>
     <awaitility.version>3.1.6</awaitility.version>
-    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
-    <cdap.plugin.version>2.13.0-SNAPSHOT</cdap.plugin.version>
+    <cdap.version>6.11.0</cdap.version>
+    <cdap.plugin.version>2.13.0</cdap.plugin.version>
     <commons.version>3.9</commons.version>
     <common.codec.version>1.12</common.codec.version>
     <gson.version>2.8.5</gson.version>


### PR DESCRIPTION
Update CDAP version to 6.11.0 in pom.xml, as snapshot is not available in repo causing build failures