### PR TITLE
[🍒][PLUGIN-1941] Set correct ssl factory when using OAUTH, CDAP OSS migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,25 +52,10 @@
     <url>https://issues.cask.co/browse/CDAP</url>
   </issueManagement>
 
-  <distributionManagement>
-    <repository>
-      <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <site>
-      <id>cdap</id>
-      <url>http://cdap.io</url>
-    </site>
-  </distributionManagement>
-
   <repositories>
     <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
-    </repository>
-    <repository>
       <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
     </repository>
   </repositories>
 

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -83,6 +83,13 @@ public class OAuthUtil {
         // get accessToken from service account
         return OAuthUtil.getAccessTokenByServiceAccount(config);
       case OAUTH2:
+        if (config instanceof BaseHttpSourceConfig) {
+          try (CloseableHttpClient client = HttpClients.custom()
+              .setSSLSocketFactory(new SSLConnectionSocketFactoryCreator((BaseHttpSourceConfig) config).create())
+              .build()) {
+            return getAccessToken(client, config);
+          }
+        }
         try (CloseableHttpClient client = HttpClients.createDefault()) {
           return getAccessToken(client, config);
         }

--- a/src/main/java/io/cdap/plugin/http/common/pagination/IncrementAnIndexPaginationIterator.java
+++ b/src/main/java/io/cdap/plugin/http/common/pagination/IncrementAnIndexPaginationIterator.java
@@ -44,6 +44,12 @@ public class IncrementAnIndexPaginationIterator extends BaseHttpPaginationIterat
     // if loadFromState() hasn't already set it
     if (index == null) {
       this.index = config.getStartIndex() - this.indexIncrement;
+    } else {
+      // When resuming from state, getCurrentState() saved the index after it was
+      // already advanced by getNextPageUrl(). Subtract the increment so that the
+      // getNextPageUrl() call below produces the correct next page URL instead of
+      // skipping a page due to double-incrementing.
+      this.index -= this.indexIncrement;
     }
 
     this.nextPageUrl = getNextPageUrl();

--- a/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
+++ b/src/main/java/io/cdap/plugin/http/source/batch/HttpBatchSourceConfig.java
@@ -20,7 +20,9 @@ import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.plugin.http.common.http.AuthType;
 import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.KeyStoreType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
+import io.cdap.plugin.http.common.http.SSLConnectionSocketFactoryCreator;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
@@ -70,7 +72,8 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
       !containsMacro(PROPERTY_PROXY_PASSWORD) && !containsMacro(PROPERTY_PROXY_USERNAME) &&
       !containsMacro(PROPERTY_PROXY_URL) && !containsMacro(PROPERTY_OAUTH2_CLIENT_AUTHENTICATION) &&
       !containsMacro(PROPERTY_OAUTH2_GRANT_TYPE)) {
-      HttpClientBuilder httpclientBuilder = HttpClients.custom();
+      HttpClientBuilder httpclientBuilder = HttpClients.custom()
+          .setSSLSocketFactory(new SSLConnectionSocketFactoryCreator(this).create());
       if (!Strings.isNullOrEmpty(getProxyUrl())) {
         HttpHost proxyHost = HttpHost.create(getProxyUrl());
         if (!Strings.isNullOrEmpty(getProxyUsername()) && !Strings.isNullOrEmpty(getProxyPassword())) {
@@ -140,6 +143,7 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     this.readTimeout = builder.readTimeout;
     this.paginationType = builder.paginationType;
     this.verifyHttps = builder.verifyHttps;
+    this.keystoreType = builder.keystoreType;
     this.authType = builder.authType;
     this.authUrl = builder.authUrl;
     this.clientId = builder.clientId;
@@ -180,6 +184,7 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
     private Integer readTimeout;
     private String paginationType;
     private String verifyHttps;
+    private String keystoreType;
     private String authType;
     private String authUrl;
     private String tokenUrl;
@@ -342,6 +347,11 @@ public class HttpBatchSourceConfig extends BaseHttpSourceConfig {
 
     public HttpBatchSourceConfigBuilder setAuthType(String authType) {
       this.authType = authType;
+      return this;
+    }
+
+    public  HttpBatchSourceConfigBuilder setKeystoreType(KeyStoreType keystoreTypeObj) {
+      this.keystoreType = keystoreTypeObj.getValue();
       return this;
     }
 

--- a/src/test/java/io/cdap/plugin/http/etl/BaseHttpBatchSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/http/etl/BaseHttpBatchSourceETLTest.java
@@ -64,7 +64,7 @@ public abstract class BaseHttpBatchSourceETLTest extends HydratorTestBase {
   public TestName name = new TestName();
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule();
+  public WireMockRule wireMockRule = new WireMockRule(0);
 
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-pipeline", "3.2.0");
 

--- a/src/test/java/io/cdap/plugin/http/etl/HttpSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/http/etl/HttpSourceETLTest.java
@@ -42,7 +42,7 @@ public abstract class HttpSourceETLTest extends HydratorTestBase {
   @Rule
   public TestName testName = new TestName();
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule();
+  public WireMockRule wireMockRule = new WireMockRule(0);
 
   @Test
   public void testIncrementAnIndex() throws Exception {

--- a/src/test/java/io/cdap/plugin/http/etl/HttpStreamingSourceETLTest.java
+++ b/src/test/java/io/cdap/plugin/http/etl/HttpStreamingSourceETLTest.java
@@ -50,8 +50,8 @@ public class HttpStreamingSourceETLTest extends HttpSourceETLTest {
   private static final Logger LOG = LoggerFactory.getLogger(HttpStreamingSourceETLTest.class);
   private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("data-streams", "1.0.0");
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("data-streams", "1.0.0");
-  private static final int WAIT_FOR_RECORDS_TIMEOUT_SECONDS = 60;
-  private static final long WAIT_FOR_RECORDS_POLLING_INTERVAL_MS = 100;
+  private static final int WAIT_FOR_RECORDS_TIMEOUT_SECONDS = 300;
+  private static final long WAIT_FOR_RECORDS_POLLING_INTERVAL_MS = 200;
 
   @BeforeClass
   public static void setupTest() throws Exception {
@@ -100,7 +100,7 @@ public class HttpStreamingSourceETLTest extends HttpSourceETLTest {
 
     ProgramManager programManager =
       deployETL(sourceConfig, sinkConfig, "HTTPStreaming_" + testName.getMethodName());
-    programManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 30, TimeUnit.SECONDS);
+    programManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 120, TimeUnit.SECONDS);
 
     return programManager;
   }
@@ -120,7 +120,7 @@ public class HttpStreamingSourceETLTest extends HttpSourceETLTest {
       }));
 
     programManager.stop();
-    programManager.waitForStopped(10, TimeUnit.SECONDS);
+    programManager.waitForStopped(120, TimeUnit.SECONDS);
 
     return MockSink.readOutput(outputManager);
   }

--- a/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
+++ b/src/test/java/io/cdap/plugin/http/source/common/HttpBatchSourceConfigTest.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import io.cdap.plugin.http.common.http.HttpClient;
+import io.cdap.plugin.http.common.http.KeyStoreType;
 import io.cdap.plugin.http.common.http.OAuthUtil;
 import io.cdap.plugin.http.common.pagination.BaseHttpPaginationIterator;
 import io.cdap.plugin.http.common.pagination.PaginationIteratorFactory;
@@ -53,7 +54,7 @@ import java.io.IOException;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PaginationIteratorFactory.class, HttpClientBuilder.class, HttpClients.class, OAuthUtil.class,
   HttpHost.class, EntityUtils.class, HttpClient.class})
-@PowerMockIgnore("javax.management.*")
+@PowerMockIgnore({"javax.management.*", "javax.net.ssl.*"})
 public class HttpBatchSourceConfigTest {
 
   @Mock
@@ -74,8 +75,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:")
       .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).build();
     config.validate(collector);
   }
 
@@ -85,7 +86,7 @@ public class HttpBatchSourceConfigTest {
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
       .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
       .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").build();
+      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).build();
     config.validateSchema();
   }
 
@@ -96,8 +97,8 @@ public class HttpBatchSourceConfigTest {
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
         .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
-        .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2")
+        .setClientId("id").setClientSecret("secret").setRefreshToken("token").setScopes("scope")
         .setTokenUrl("https//:token").setRetryPolicy("exponential")
         .setOauth2GrantType("refresh_token").build();
     PowerMockito.mockStatic(PaginationIteratorFactory.class);
@@ -124,9 +125,10 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
       .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
-      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2")
+        .setClientId("id").setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy(
         "exponential").setProxyUrl("https://proxy").setProxyUsername("proxyuser").setProxyPassword("proxypassword")
         .setOauth2GrantType("refresh_token").build();
     HttpClientBuilder httpClientBuilder = Mockito.mock(HttpClientBuilder.class);
@@ -156,10 +158,10 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
         .setFormat("JSON").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id").
-      setClientSecret("secret").setRefreshToken("token").setScopes("scope").setTokenUrl("https//:token").setRetryPolicy(
-            "exponential").setOauth2GrantType("refresh_token").build();
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2")
+        .setClientId("id").setClientSecret("secret").setRefreshToken("token").setScopes("scope")
+        .setTokenUrl("https//:token").setRetryPolicy("exponential").setOauth2GrantType("refresh_token").build();
     CloseableHttpClient httpClientMock = Mockito.mock(CloseableHttpClient.class);
     CloseableHttpResponse httpResponse = Mockito.mock(CloseableHttpResponse.class);
     Mockito.when(httpClientMock.execute(Mockito.any())).thenReturn(httpResponse);
@@ -193,10 +195,9 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
       .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
-        "username").setPassword("password").setRetryPolicy(
-        "exponential").build();
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("basicAuth")
+        .setUsername("username").setPassword("password").setRetryPolicy("exponential").build();
     Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
     Mockito.when(response.getStatusLine()).thenReturn(statusLine);
     Mockito.when(statusLine.getStatusCode()).thenReturn(200);
@@ -210,10 +211,9 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder()
       .setReferenceName("test").setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth")
       .setFormat("JSON").setAuthType("none").setErrorHandling(StringUtils.EMPTY)
-      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120)
-      .setReadTimeout(120).setPaginationType("NONE").setVerifyHttps("true").setAuthType("basicAuth").setUsername(
-        "username").setPassword("password").setRetryPolicy(
-        "exponential").build();
+      .setRetryPolicy(StringUtils.EMPTY).setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
+        .setPaginationType("NONE").setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("basicAuth")
+        .setUsername("username").setPassword("password").setRetryPolicy("exponential").build();
     Mockito.when(httpClient.executeHTTP(Mockito.any())).thenReturn(response);
     Mockito.when(response.getStatusLine()).thenReturn(statusLine);
     Mockito.when(statusLine.getStatusCode()).thenReturn(400);
@@ -232,8 +232,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
         .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
         .setOauth2ClientAuthentication("body").build();
@@ -264,8 +264,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
         .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
         .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
@@ -298,8 +298,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
         .setTokenUrl("https//:token").setRetryPolicy("exponential")
         .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("body").build();
@@ -339,8 +339,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
         .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
         .setOauth2ClientAuthentication("request_parameter").build();
@@ -371,8 +371,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
         .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
         .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
@@ -406,8 +406,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
         .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
         .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-        .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+        .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
         .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
         .setTokenUrl("https//:token").setRetryPolicy("exponential")
         .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("request_parameter")
@@ -448,8 +448,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
       .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
       .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
       .setClientSecret("secret").setScopes("scope").setTokenUrl("https//:token")
       .setRetryPolicy("exponential").setOauth2GrantType("client_credentials")
       .setOauth2ClientAuthentication("basic_auth_header").build();
@@ -480,8 +480,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
       .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
       .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
       .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
       .setTokenUrl("https//:token").setRetryPolicy("exponential").setProxyUrl("https://proxy")
       .setProxyUsername("proxyuser").setProxyPassword("proxypassword")
@@ -515,8 +515,8 @@ public class HttpBatchSourceConfigTest {
     HttpBatchSourceConfig config = HttpBatchSourceConfig.builder().setReferenceName("test")
       .setUrl("http://localhost").setHttpMethod("GET").setHeaders("Auth:auth").setFormat("JSON")
       .setErrorHandling(StringUtils.EMPTY).setRetryPolicy(StringUtils.EMPTY)
-      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120)
-      .setPaginationType("NONE").setVerifyHttps("true").setAuthType("oAuth2").setClientId("id")
+      .setMaxRetryDuration(600L).setConnectTimeout(120).setReadTimeout(120).setPaginationType("NONE")
+        .setVerifyHttps("false").setKeystoreType(KeyStoreType.JKS).setAuthType("oAuth2").setClientId("id")
       .setClientSecret("secret").setRefreshToken("token").setScopes("scope")
       .setTokenUrl("https//:token").setRetryPolicy("exponential")
       .setOauth2GrantType("client_credentials").setOauth2ClientAuthentication("basic_auth_header")


### PR DESCRIPTION
## 🍒 CDAP OSS migration

cherry-pick for [6.11]

commit : be4a86900e6201ba11b28a332d3ea5de90e4cdd4
pull request : #198

---

## 🍒 [PLUGIN-1941] Set correct ssl factory when using OAUTH#200

commit : b6448f6b9b224d80607b4c33675a9a95e97c4fe8
pull request : #200

Jira : [PLUGIN-1941](https://cdap.atlassian.net/browse/PLUGIN-1941)

### Description

- adds correct ssl factory when using oauth


### Bug
HTTP Plugin does not skip SSL cert validation when using OAUTH


### Steps to recreate
1. Use any https endpoint with self signed SSL cert
2. Turn off SSL cert validation
3. Try to request with any auth (say basic auth) and then with OAUTH

OAuth will fail will cert errors

[PLUGIN-1941]: https://cdap.atlassian.net/browse/PLUGIN-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ