### PR TITLE
Remove SNAPSHOT version for HTTP Plugins release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.5.1</version>
 
   <licenses>
     <license>


### PR DESCRIPTION
Remove SNAPSHOT version for HTTP Plugins release