### PR TITLE
[🍒]Bump HTTP Plugins version to 1.5.2-SNAPSHOT & Auth fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <name>HTTP Plugins</name>
   <groupId>io.cdap</groupId>
   <artifactId>http-plugins</artifactId>
-  <version>1.5.1</version>
+  <version>1.5.2-SNAPSHOT</version>
 
   <licenses>
     <license>

--- a/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
+++ b/src/main/java/io/cdap/plugin/http/common/http/OAuthUtil.java
@@ -24,11 +24,17 @@ import io.cdap.plugin.http.common.BaseHttpConfig;
 import io.cdap.plugin.http.common.OAuth2GrantType;
 import io.cdap.plugin.http.common.pagination.page.JSONUtil;
 import io.cdap.plugin.http.source.common.BaseHttpSourceConfig;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
@@ -83,14 +89,26 @@ public class OAuthUtil {
         // get accessToken from service account
         return OAuthUtil.getAccessTokenByServiceAccount(config);
       case OAUTH2:
+        HttpClientBuilder httpClientBuilder = HttpClients.custom();
+
         if (config instanceof BaseHttpSourceConfig) {
-          try (CloseableHttpClient client = HttpClients.custom()
-              .setSSLSocketFactory(new SSLConnectionSocketFactoryCreator((BaseHttpSourceConfig) config).create())
-              .build()) {
-            return getAccessToken(client, config);
-          }
+          httpClientBuilder.setSSLSocketFactory(
+                  new SSLConnectionSocketFactoryCreator((BaseHttpSourceConfig) config).create()
+          );
         }
-        try (CloseableHttpClient client = HttpClients.createDefault()) {
+        // Apply Proxy settings if they exist
+        if (!Strings.isNullOrEmpty(config.getProxyUrl())) {
+          HttpHost proxyHost = HttpHost.create(config.getProxyUrl());
+
+          if (!Strings.isNullOrEmpty(config.getProxyUsername()) && !Strings.isNullOrEmpty(config.getProxyPassword())) {
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(new AuthScope(proxyHost),
+                    new UsernamePasswordCredentials(config.getProxyUsername(), config.getProxyPassword()));
+            httpClientBuilder.setDefaultCredentialsProvider(credsProvider);
+          }
+          httpClientBuilder.setProxy(proxyHost);
+        }
+        try (CloseableHttpClient client = httpClientBuilder.build()) {
           return getAccessToken(client, config);
         }
     }


### PR DESCRIPTION
## Added a fix for OAuth2 Proxy Routing

Jira : [PLUGIN-1956](https://cdap.atlassian.net/browse/PLUGIN-1956)

### Description

When the HTTP plugin (source or sink) is configured with OAuth2 authentication and a proxy (proxyUrl, proxyUsername, proxyPassword), the request that fetches the OAuth2 access token ignores the proxy settings. It is sent directly to the token endpoint, which causes an UnknownHostException in restricted environments (like Cloud Data Fusion / Dataproc) where only the proxy has outbound network access.
Root Cause
In OAuthUtil.getAccessToken(BaseHttpConfig config), the code builds its own HTTP client but never applies the proxy settings from the config. Currently, it uses HttpClients.custom() (for the source path) or HttpClients.createDefault() (for the sink path), completely bypassing setProxy(...) and setDefaultCredentialsProvider(...).

### The Fix
Refactored the OAUTH2 case in OAuthUtil.java to use a unified HttpClientBuilder. The builder now:
Conditionally applies the SSLConnectionSocketFactory (if it's a BaseHttpSourceConfig).
Extracts the proxy settings from the config object and applies the HttpHost and BasicCredentialsProvider (if configured) before calling .build().

### Proof / Verifications

- Pipeline execution logs showing the UnknownHostException failing to resolve the token URL in a restricted environment prior to this fix.
<img width="1427" height="931" alt="i1" src="https://github.com/user-attachments/assets/7f7802d6-4b81-457c-9cd7-2ed2f8f6a129" />


- Local mock proxy server logs confirming that the POST /token request is now successfully intercepted and routed through the configured proxy port.


<img width="1600" height="819" alt="i2" src="https://github.com/user-attachments/assets/58d51d30-2dcb-4bb7-b539-acdfcaf23516" />


<img width="1600" height="648" alt="i3" src="https://github.com/user-attachments/assets/90f0ca1a-25e1-484f-a3c0-d0540e755b7d" />


<img width="1600" height="208" alt="i4" src="https://github.com/user-attachments/assets/5d8418df-7479-457f-aa40-decc211074b7" />


[PLUGIN-1956]: https://cdap.atlassian.net/browse/PLUGIN-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ